### PR TITLE
Make WithDefault to provide a deep copy of the provided default value

### DIFF
--- a/static_provider_test.go
+++ b/static_provider_test.go
@@ -325,8 +325,10 @@ func TestConfigDefaultsAreOverriddenByHigherPriorityProviders(t *testing.T) {
 		NewStaticProvider(map[string]string{
 			"library.author": "Dreiser",
 			"library.title":  "The Financier"},
-		).Get("library").
-			WithDefault(book{Title: "An American Tragedy", Year: 1925}).Populate(&novel),
+		).Get("library").WithDefault(book{
+			Title: "An American Tragedy",
+			Year:  1925,
+		}).Populate(&novel),
 		"Failed to write a novel.",
 	)
 	assert.Equal(t, book{Title: "The Financier", Author: "Dreiser", Year: 1925}, novel)

--- a/static_provider_test.go
+++ b/static_provider_test.go
@@ -295,3 +295,39 @@ func TestValue_ChildKeys(t *testing.T) {
 	p = NewStaticProvider(map[int]string{3: "three", 5: "five"})
 	t.Run("MapOfInts", func(t *testing.T) { op(t, Root, []string{"3", "5"}) })
 }
+
+func TestConfigDefaults(t *testing.T) {
+	t.Parallel()
+
+	type cfg struct{ N int }
+
+	var c cfg
+	require.NoError(
+		t,
+		NewStaticProvider(nil).Get("metrics").WithDefault(cfg{42}).Populate(&c),
+		"Failed to populate config.",
+	)
+	assert.Equal(t, cfg{N: 42}, c)
+}
+
+func TestConfigDefaultsAreOverriddenByHigherPriorityProviders(t *testing.T) {
+	t.Parallel()
+
+	type book struct {
+		Title  string
+		Author string
+		Year   int
+	}
+
+	var novel book
+	require.NoError(
+		t,
+		NewStaticProvider(map[string]string{
+			"library.author": "Dreiser",
+			"library.title":  "The Financier"},
+		).Get("library").
+			WithDefault(book{Title: "An American Tragedy", Year: 1925}).Populate(&novel),
+		"Failed to write a novel.",
+	)
+	assert.Equal(t, book{Title: "The Financier", Author: "Dreiser", Year: 1925}, novel)
+}

--- a/value.go
+++ b/value.go
@@ -136,7 +136,7 @@ func (cv Value) LastUpdated() time.Time {
 	return cv.Timestamp
 }
 
-// WithDefault creates sets the default value that can be overridden
+// WithDefault sets the default value that can be overridden
 // by providers with a highger priority.
 func (cv Value) WithDefault(value interface{}) Value {
 	cv.defaultValue = value

--- a/value.go
+++ b/value.go
@@ -136,16 +136,11 @@ func (cv Value) LastUpdated() time.Time {
 	return cv.Timestamp
 }
 
-// WithDefault creates a shallow copy of the current configuration value and
-// sets its default.
+// WithDefault creates sets the default value that can be overridden
+// by providers with a highger priority.
 func (cv Value) WithDefault(value interface{}) Value {
-	// TODO: create a "DefaultProvider" and chain that into the bottom of the current provider:
-	//
-	// provider = NewProviderGroup(defaultProvider, cv.provider)
-	//
-	cv2 := cv
-	cv2.defaultValue = value
-	return cv2
+	cv.root = NewProviderGroup("withDefault", NewStaticProvider(map[string]interface{}{cv.key: value}), cv.provider)
+	return cv
 }
 
 // ChildKeys returns the child keys

--- a/value.go
+++ b/value.go
@@ -139,6 +139,7 @@ func (cv Value) LastUpdated() time.Time {
 // WithDefault creates sets the default value that can be overridden
 // by providers with a highger priority.
 func (cv Value) WithDefault(value interface{}) Value {
+	cv.defaultValue = value
 	cv.root = NewProviderGroup("withDefault", NewStaticProvider(map[string]interface{}{cv.key: value}), cv.provider)
 	return cv
 }


### PR DESCRIPTION
WithDefaultValue replaces only a default value, which makes it to work only with scalar types, but more complex types will [fail](https://github.com/uber-go/config/issues/16).
We can update the provider saved in value to be a grouped provider of the original provider and a static provider based on the provided value.