### PR TITLE
Use APP_ROOT to resolve configuration path(s)

### DIFF
--- a/config.go
+++ b/config.go
@@ -99,6 +99,14 @@ func NewLoader(providers ...ProviderFunc) *Loader {
 var TestConfig = func() Provider {
 	l := NewLoader()
 	l.SetConfigFiles(_baseFile, "test.yaml")
+	l.SetDirs(func() []string {
+		dirs := []string{}
+		root := l.AppRoot()
+		for _, dir := range l.dirs {
+			dirs = append(dirs, fmt.Sprintf("%s/%s", root, dir))
+		}
+		return dirs
+	}()...)
 	return l.Load()
 }()
 


### PR DESCRIPTION
When using `config.TestConfig` in our application, we were not reading the configuration files from the application root's `config/` directory. This change makes it so that we read from the root if the APP_ROOT variable is set, or the current working directory otherwise.