### PR TITLE
Check implementation of TextUnmarshaller on all types

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -460,8 +460,8 @@ func (d *decoder) pointer(name string, value reflect.Value, def string) error {
 // so we are going to stringify them manually.
 func jsonMap(v interface{}) interface{} {
 	if reflect.TypeOf(v).Kind() == reflect.Map {
-		tmp := make(map[string]interface{}, len(rv.MapKeys()))
 		rv := reflect.ValueOf(v)
+		tmp := make(map[string]interface{}, len(rv.MapKeys()))
 		for _, key := range rv.MapKeys() {
 			tmp[fmt.Sprint(key.Interface())] = jsonMap(rv.MapIndex(key).Interface())
 		}

--- a/decoder.go
+++ b/decoder.go
@@ -30,8 +30,8 @@ import (
 	"strconv"
 
 	"github.com/go-validator/validator"
+	"github.com/go-yaml/yaml"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
 )
 
 type fieldInfo struct {

--- a/decoder.go
+++ b/decoder.go
@@ -460,7 +460,7 @@ func (d *decoder) pointer(name string, value reflect.Value, def string) error {
 // so we are going to stringify them manually.
 func jsonMap(v interface{}) interface{} {
 	if reflect.TypeOf(v).Kind() == reflect.Map {
-		tmp := make(map[string]interface{})
+		tmp := make(map[string]interface{}, len(rv.MapKeys()))
 		rv := reflect.ValueOf(v)
 		for _, key := range rv.MapKeys() {
 			tmp[fmt.Sprint(key.Interface())] = jsonMap(rv.MapIndex(key).Interface())

--- a/value.go
+++ b/value.go
@@ -21,7 +21,6 @@
 package config
 
 import (
-	"encoding"
 	"fmt"
 	"reflect"
 	"time"
@@ -286,13 +285,9 @@ func convertValue(value interface{}, targetType reflect.Type) (interface{}, erro
 	switch v := value.(type) {
 	case string:
 		target := reflect.New(targetType).Interface()
-		switch t := target.(type) {
+		switch target.(type) {
 		case *time.Duration:
 			return time.ParseDuration(v)
-		case encoding.TextUnmarshaler:
-			err := t.UnmarshalText([]byte(v))
-			// target should have a pointer receiver to be able to change itself based on text
-			return reflect.ValueOf(target).Elem().Interface(), err
 		}
 	}
 

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -1146,8 +1146,8 @@ func TestPopulateOfJSONUnmarshal(t *testing.T) {
 
 type jsonMarshalError struct{}
 
-func (j *jsonMarshalError) UnmarshalJSON(b []byte) error {return nil}
-func (j jsonMarshalError) MarshalJSON() ([]byte, error) {return nil, errors.New("never give up")}
+func (j *jsonMarshalError) UnmarshalJSON(b []byte) error { return nil }
+func (j jsonMarshalError) MarshalJSON() ([]byte, error)  { return nil, errors.New("never give up") }
 
 func TestPopulateOfFailedJSONMarshal(t *testing.T) {
 	t.Parallel()
@@ -1165,7 +1165,7 @@ type yamlUnmarshal struct {
 	Name string
 }
 
-func (y *yamlUnmarshal) UnmarshalYAML(unmarshal func(interface{}) error) error{
+func (y *yamlUnmarshal) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type fakeYAMLUnmarshal struct {
 		Size int
 		Name string
@@ -1174,7 +1174,7 @@ func (y *yamlUnmarshal) UnmarshalYAML(unmarshal func(interface{}) error) error{
 	var f fakeYAMLUnmarshal
 
 	if err := unmarshal(&f); err == nil {
-		y.Name = f.Name+ "Fake"
+		y.Name = f.Name + "Fake"
 		y.Size = f.Size
 		return nil
 	}
@@ -1184,7 +1184,7 @@ func (y *yamlUnmarshal) UnmarshalYAML(unmarshal func(interface{}) error) error{
 		return err
 	}
 
-	stringToInt := map[string]int {"one":1, "two":2}
+	stringToInt := map[string]int{"one": 1, "two": 2}
 	y.Size = stringToInt[m["size"]]
 	y.Name = m["name"]
 


### PR DESCRIPTION
`Populate` is using `encoding.TextUnmarshaller` interface only on scalar types, 
functions and channels, but any type can implement it, e.g. [zap.AtomicLevel](https://github.com/uber-go/zap/blob/master/level.go#L109)

We are using `Value.String()` to construct the byte array. In case of scalar types
received from a provider, text does not need extra formatting. `TextUnmarshaller`
implementation should be aware of the source of the values for complex types.
For example in `TestUnmarshalTextOnComplexStruct` the actual contents of byte 
array are `map[year:1994 title:Free Willy]`