### PR TITLE
Check underlying collection types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v1.0.0-rc2 (unreleased)
 
-- No changes yet.
+- **[Breaking]** `ValueType` and `GetType` functionality is removed in favor of using
+  `reflect.Kind`
 
 ## v1.0.0-rc1 (26 Jun 2017)
 

--- a/cache_provider_test.go
+++ b/cache_provider_test.go
@@ -61,7 +61,7 @@ func TestCachedProvider_GetNewValues(t *testing.T) {
 			t.Fatal("cache was called more than once")
 		}
 		count++
-		return NewValue(m, key, "Simpsons", true, String, nil)
+		return NewValue(m, key, "Simpsons", true, nil)
 	}
 
 	p := NewCachedProvider(m)
@@ -83,21 +83,19 @@ func TestCachedProviderConcurrentUse(t *testing.T) {
 	m := testCachedProvider{}
 	var count int32
 	m.f = func(key string) Value {
-		if atomic.LoadInt32(&count) > 0 {
-			t.Fatal("cache was called more than once")
+		if atomic.LoadInt32(&count) > 1 {
+			t.Fatal("cache was called more than twice")
 		}
 
-		atomic.AddInt32(&count, 1)
-		return NewValue(m, key, "Simpsons", true, String, nil)
+		return NewValue(m, key, "Simpsons", true, nil)
 	}
 
 	p := NewCachedProvider(m)
-
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 	get := func() {
 		x := p.Get(Root)
-		require.True(t, x.HasValue())
+		assert.True(t, x.HasValue())
 		wg.Done()
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -267,7 +267,7 @@ func TestGetAsIntegerValue(t *testing.T) {
 		{int64(2)},
 	}
 	for _, tc := range testCases {
-		cv := NewValue(NewStaticProvider(nil), "key", tc.value, true, Integer, nil)
+		cv := NewValue(NewStaticProvider(nil), "key", tc.value, true, nil)
 		assert.Equal(t, 2, cv.AsInt())
 	}
 }
@@ -284,7 +284,7 @@ func TestGetAsFloatValue(t *testing.T) {
 		{int64(2)},
 	}
 	for _, tc := range testCases {
-		cv := NewValue(NewStaticProvider(nil), "key", tc.value, true, Float, nil)
+		cv := NewValue(NewStaticProvider(nil), "key", tc.value, true, nil)
 		assert.Equal(t, float64(2), cv.AsFloat())
 	}
 }

--- a/decoder.go
+++ b/decoder.go
@@ -272,11 +272,7 @@ func checkCollections(src, dst reflect.Kind) error {
 		if src != reflect.Map {
 			return err
 		}
-	case reflect.Array:
-		if src != reflect.Array && src != reflect.Slice {
-			return err
-		}
-	case reflect.Slice:
+	case reflect.Array, reflect.Slice:
 		if src != reflect.Array && src != reflect.Slice {
 			return err
 		}
@@ -285,7 +281,15 @@ func checkCollections(src, dst reflect.Kind) error {
 	return nil
 }
 
-// Set value for a sequence type
+// Set value for a sequence type. Length of the collection is determined by the length of
+// the underlying collection in a provider. It can be augmented further, by overriding values
+// after the end, e.g.
+// var x []int
+// NewStaticProvider(map[string]interface{}{"a":[]int{0,1}, "a.2":2}.Populate(&x)
+// fmt.Println(x)
+//
+// will print:
+// [0 1 2]
 func (d *decoder) sequence(childKey string, value reflect.Value) error {
 	global := d.getGlobalProvider()
 	slice := global.Get(childKey)
@@ -346,7 +350,8 @@ func (d *decoder) sequence(childKey string, value reflect.Value) error {
 	return nil
 }
 
-// Set value for the array type
+// Set value for the array type. If a value for array item is not found, decoder will use
+// a default one if present, or a zero constructed.
 func (d *decoder) array(childKey string, value reflect.Value) error {
 	global := d.getGlobalProvider()
 	ar := global.Get(childKey)

--- a/decoder.go
+++ b/decoder.go
@@ -262,9 +262,9 @@ func (d *decoder) scalar(childKey string, value reflect.Value, def string) error
 	return convert(childKey, &value, val)
 }
 
-// Collections of objects can be  converted in the following way:
-// Maps can be decoded only to maps and slices with arrays can be
-// decoded one into another.
+// Collections of objects can be converted in the following way:
+// 1. Maps can be decoded only to maps
+// 2. Slices with arrays can be decoded one into another.
 func checkCollections(src, dst reflect.Kind) error {
 	err := errors.Errorf("can't convert %q to %q", src, dst)
 	switch dst {
@@ -284,6 +284,7 @@ func checkCollections(src, dst reflect.Kind) error {
 // Set value for a sequence type. Length of the collection is determined by the length of
 // the underlying collection in a provider. It can be augmented further, by overriding values
 // after the end, e.g.
+//
 // var x []int
 // NewStaticProvider(map[string]interface{}{"a":[]int{0,1}, "a.2":2}.Populate(&x)
 // fmt.Println(x)

--- a/decoder.go
+++ b/decoder.go
@@ -281,13 +281,13 @@ func checkCollections(src, dst reflect.Kind) error {
 	return nil
 }
 
-// Set value for a sequence type. Length of the collection is determined by the length of
-// the underlying collection in a provider. It can be augmented further, by overriding values
-// after the end, e.g.
+// Set value for a sequence type. Length of the collection is determined by the
+// length of the underlying collection in a provider. It can be augmented
+// further, by overriding values after the end, e.g.
 //
-// var x []int
-// NewStaticProvider(map[string]interface{}{"a":[]int{0,1}, "a.2":2}.Populate(&x)
-// fmt.Println(x)
+// 	var x []int
+// 	NewStaticProvider(map[string]interface{}{"a":[]int{0,1}, "a.2":2}.Populate(&x)
+// 	fmt.Println(x)
 //
 // will print:
 // [0 1 2]
@@ -328,7 +328,8 @@ func (d *decoder) sequence(childKey string, value reflect.Value) error {
 			destSlice = reflect.Append(destSlice, reflect.Zero(elementType))
 			destSlice.Index(ai).Set(val)
 		} else {
-			// Value in the middle was overridden, but is missing, set it to the zero initialized value.
+			// Value in the middle was overridden,
+			// but is missing, set it to the zero initialized value.
 			if sv.IsValid() && sv.Len() > ai {
 
 				// Append element to the slice
@@ -347,8 +348,8 @@ func (d *decoder) sequence(childKey string, value reflect.Value) error {
 	return nil
 }
 
-// Set value for the array type. If a value for array item is not found, decoder will use
-// a default one if present, or a zero constructed.
+// Set value for the array type. If a value for array item is not found,
+// decoder will use a default one if present, or a zero constructed.
 func (d *decoder) array(childKey string, value reflect.Value) error {
 	global := d.getGlobalProvider()
 	ar := global.Get(childKey)
@@ -528,7 +529,8 @@ func jsonMap(v interface{}) interface{} {
 	return v
 }
 
-// tryUnmarshallers checks if the value's type implements either one of standard interfaces in order:
+// tryUnmarshallers checks if the value's type implements either one of standard
+// interfaces in order:
 // 1. `json.Unmarshaler`
 // 2. `encoding.TextUnmarshaler`
 // 3. `yaml.Unmarshaler`

--- a/decoder.go
+++ b/decoder.go
@@ -324,18 +324,14 @@ func (d *decoder) sequence(childKey string, value reflect.Value) error {
 			}
 
 			// Append element to the slice
-			if destSlice.Len() <= ai {
-				destSlice = reflect.Append(destSlice, reflect.Zero(elementType))
-			}
-
+			destSlice = reflect.Append(destSlice, reflect.Zero(elementType))
 			destSlice.Index(ai).Set(val)
 		} else {
-			// Value in the middle aws overridden, but is missing, set it to zero initialized value.
+			// Value in the middle was overridden, but is missing, set it to the zero initialized value.
 			if sv.IsValid() && sv.Len() > ai {
-				if destSlice.Len() <= ai {
-					destSlice = reflect.Append(destSlice, reflect.Zero(elementType))
-				}
 
+				// Append element to the slice
+				destSlice = reflect.Append(destSlice, reflect.Zero(elementType))
 				continue
 			}
 

--- a/nop_provider.go
+++ b/nop_provider.go
@@ -35,5 +35,5 @@ func (p NopProvider) Name() string {
 
 // Get returns an invalid Value.
 func (p NopProvider) Get(key string) Value {
-	return NewValue(p, key, nil, true, Invalid, &time.Time{})
+	return NewValue(p, key, nil, true, &time.Time{})
 }

--- a/provider_group.go
+++ b/provider_group.go
@@ -45,7 +45,7 @@ func (p providerGroup) Get(key string) Value {
 		}
 	}
 
-	cv := NewValue(p, key, res, found, GetType(res), nil)
+	cv := NewValue(p, key, res, found, nil)
 
 	// here we add a new root, which defines the "scope" at which
 	// Populates will look for values.

--- a/static_provider_test.go
+++ b/static_provider_test.go
@@ -22,11 +22,10 @@ package config
 
 import (
 	"fmt"
-	"sort"
-	"testing"
-
 	"io/ioutil"
+	"sort"
 	"strings"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/static_provider_test.go
+++ b/static_provider_test.go
@@ -25,10 +25,11 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"strings"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStaticProvider_Name(t *testing.T) {
@@ -198,7 +199,7 @@ func TestPopulateForNestedMaps(t *testing.T) {
 	p := NewStaticProvider(map[string]map[string]string{
 		"a": {"one": "1", "": ""}})
 
-	var m map[string]map[string]string
+	var m map[string]string
 	err := p.Get("a").Populate(&m)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `empty map key is ambiguous`)
@@ -285,6 +286,7 @@ func TestValue_ChildKeys(t *testing.T) {
 
 	t.Run("Map", func(t *testing.T) { op(t, Root, []string{"one", "slice", "two"}) })
 	t.Run("Slice", func(t *testing.T) { op(t, "slice", []string{"0", "1"}) })
+	t.Run("SingleValue", func(t *testing.T) { op(t, "one", nil) })
 	t.Run("Empty", func(t *testing.T) { op(t, "nothing", nil) })
 
 	p = NewStaticProvider(map[int]string{3: "three", 5: "five"})

--- a/value_provider.go
+++ b/value_provider.go
@@ -31,7 +31,7 @@ func (m *valueProvider) Get(key string) Value {
 }
 
 func newValueProvider(val interface{}) Provider {
-	p := &valueProvider{Value: Value{found: true, value: val, Type: GetType(val)}}
+	p := &valueProvider{Value: Value{found: true, value: val}}
 	p.Value.root = p
 	return p
 }

--- a/yaml.go
+++ b/yaml.go
@@ -187,10 +187,10 @@ func (y yamlConfigProvider) Name() string {
 func (y yamlConfigProvider) Get(key string) Value {
 	node := y.getNode(key)
 	if node == nil {
-		return NewValue(y, key, nil, false, Invalid, nil)
+		return NewValue(y, key, nil, false, nil)
 	}
 
-	return NewValue(y, key, node.value, true, GetType(node.value), nil)
+	return NewValue(y, key, node.value, true, nil)
 }
 
 // Simple YAML reader

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -25,14 +25,13 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"os"
 	"reflect"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
-
-	"math"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -32,9 +32,10 @@ import (
 	"testing"
 	"time"
 
+	"math"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"math"
 )
 
 var yamlConfig1 = []byte(`
@@ -650,7 +651,7 @@ type testProvider struct {
 
 func (s *testProvider) Get(key string) Value {
 	val, found := s.a, true
-	return NewValue(s, key, val, found, GetType(val), nil)
+	return NewValue(s, key, val, found, nil)
 }
 
 func TestLoops(t *testing.T) {
@@ -1206,6 +1207,62 @@ func TestYAMLMarshallerErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "always blue!")
 }
 
+func TestYAMLFailOnMalformedData(t *testing.T) {
+	t.Parallel()
+	cfg := NewYAMLProviderFromBytes([]byte(`foo: ["a", "b", "c"]`))
+	var (
+		intMap           map[int]int
+		intList          []int
+		intArray         [2]int
+		stringListList   [][]string
+		stringArrayArray [2][2]string
+	)
+
+	assert := assert.New(t)
+	err := cfg.Get("foo").Populate(&intMap)
+	require.Error(t, err, "can't convert []string to")
+	assert.Contains(err.Error(), `expected map for key "foo". actual type: "[]interface {}"`)
+
+	err = cfg.Get("foo").Populate(&intList)
+	require.Error(t, err)
+	assert.Contains(err.Error(), `parsing "a": invalid syntax`)
+
+	err = cfg.Get("foo").Populate(&intArray)
+	require.Error(t, err)
+	assert.Contains(err.Error(), `parsing "a": invalid syntax`)
+
+	err = cfg.Get("foo").Populate(&stringListList)
+	require.Error(t, err)
+	assert.Contains(err.Error(), `can't convert "string" to "slice"`)
+
+	err = cfg.Get("foo").Populate(&stringArrayArray)
+	require.Error(t, err)
+	assert.Contains(err.Error(), `can't convert "string" to "array"`)
+}
+
+func TestJSONDecode(t *testing.T) {
+	t.Parallel()
+
+	b := []byte(`- a: b
+- c: d`)
+	var stringListList [][]string
+	cfg := NewYAMLProviderFromBytes(b)
+	err := cfg.Get("").Populate(&stringListList)
+	assert.Error(t, err)
+	assert.Len(t, stringListList, 0)
+}
+
+func TestNilsOnMaps(t *testing.T) {
+	t.Parallel()
+
+	b := []byte(``)
+	var m map[string]string
+	cfg := NewYAMLProviderFromBytes(b)
+	err := cfg.Get("").Populate(&m)
+	assert.NoError(t, err)
+	assert.Nil(t, m)
+}
+
 func TestPopulateOfYAMLUnmarshal(t *testing.T) {
 	t.Parallel()
 
@@ -1227,4 +1284,179 @@ fail:
 
 	assert.NoError(t, p.Get("fail").Populate(&y))
 	assert.Equal(t, y, yamlUnmarshal{Size: 1, Name: "first"})
+}
+
+func TestFailConversionFromMapsToSlices(t *testing.T) {
+	t.Parallel()
+
+	cfg := NewYAMLProviderFromBytes([]byte(`
+foo:
+  0: "a"
+  1: "b"
+`))
+
+	t.Run("map of ints", func(t *testing.T) {
+		var intMap map[int]string
+		err := cfg.Get("foo").Populate(&intMap)
+		require.NoError(t, err)
+		assert.Equal(t, map[int]string{0: "a", 1: "b"}, intMap)
+	})
+
+	t.Run("list of strings", func(t *testing.T) {
+		var stringList []string
+		err := cfg.Get("foo").Populate(&stringList)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `can't convert "map" to "slice"`)
+		require.Len(t, stringList, 0)
+	})
+
+	t.Run("list of strings with first overridden value", func(t *testing.T) {
+		var stringList []string
+		err := NewStaticProvider(map[string]int{"foo.0": 1}).Get("foo").Populate(&stringList)
+		require.NoError(t, err)
+		require.Len(t, stringList, 1)
+	})
+
+	t.Run("array of strings", func(t *testing.T) {
+		var stringArray [2]string
+		err := cfg.Get("foo").Populate(&stringArray)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `can't convert "map" to "array"`)
+		require.Equal(t, stringArray, [2]string{"", ""})
+	})
+
+	t.Run("list of strings", func(t *testing.T) {
+		var stringListList [][]string
+		err := cfg.Get("foo").Populate(&stringListList)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `can't convert "map" to "slice"`)
+		require.Len(t, stringListList, 0)
+	})
+
+	t.Run("nested map of ints of strings failure", func(t *testing.T) {
+		var mapIntMap map[string]map[int]string
+		err := cfg.Get("foo").Populate(&mapIntMap)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `expected map for key "foo`)
+		assert.Contains(t, err.Error(), `actual type: "string"`)
+		assert.Nil(t, mapIntMap)
+	})
+}
+
+func TestSliceElementInDifferentPositions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty slice", func(t *testing.T) {
+		p := NewStaticProvider([]int{})
+		var s []int
+		require.NoError(t, p.Get(Root).Populate(&s))
+		assert.Nil(t, s)
+	})
+
+	t.Run("first element overridden", func(t *testing.T) {
+		p := NewStaticProvider(map[string]interface{}{"a.0": 1})
+		var s []int
+		require.NoError(t, p.Get("a").Populate(&s))
+		assert.Equal(t, []int{1}, s)
+	})
+
+	t.Run("nil slice with first element overridden", func(t *testing.T) {
+		p := NewStaticProvider(map[string]interface{}{"a": nil, "a.0": 1})
+		var s []int
+		require.NoError(t, p.Get("a").Populate(&s))
+		assert.Equal(t, []int{1}, s)
+	})
+
+	t.Run("empty slice with first element overridden", func(t *testing.T) {
+		p := NewStaticProvider(map[string]interface{}{"a": []int{}, "a.0": 1})
+		var s []int
+		require.NoError(t, p.Get("a").Populate(&s))
+		assert.Equal(t, []int{1}, s)
+	})
+
+	t.Run("slice with second element overridden", func(t *testing.T) {
+		p := NewStaticProvider(map[string]interface{}{"a": []int{0, 1, 2}, "a.1": 3})
+		var s []int
+		require.NoError(t, p.Get("a").Populate(&s))
+		assert.Equal(t, []int{0, 3, 2}, s)
+	})
+
+	t.Run("slice with an extra element added", func(t *testing.T) {
+		p := NewStaticProvider(map[string]interface{}{"a": []int{0, 1, 2}, "a.3": 3})
+		var s []int
+		require.NoError(t, p.Get("a").Populate(&s))
+		assert.Equal(t, []int{0, 1, 2, 3}, s)
+	})
+
+	t.Run("slice with a nil element inside", func(t *testing.T) {
+		p := NewStaticProvider(map[string]interface{}{"a": []int{0, 1, 2}, "a.1": nil})
+		var s []int
+		require.NoError(t, p.Get("a").Populate(&s))
+		assert.Equal(t, []int{0, 0, 2}, s)
+	})
+}
+
+func TestArrayElementInDifferentPositions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty array", func(t *testing.T) {
+		p := NewStaticProvider([]int{})
+		var s [2]int
+		require.NoError(t, p.Get(Root).Populate(&s))
+		assert.Equal(t, [2]int{0, 0}, s)
+	})
+
+	t.Run("first element overridden", func(t *testing.T) {
+		p := NewStaticProvider(map[string]interface{}{"a.0": 1})
+		var s [2]int
+		require.NoError(t, p.Get("a").Populate(&s))
+		assert.Equal(t, [2]int{1, 0}, s)
+	})
+
+	t.Run("nil collection with first element overridden", func(t *testing.T) {
+		p := NewStaticProvider(map[string]interface{}{"a": nil, "a.0": 1})
+		var s [2]int
+		require.NoError(t, p.Get("a").Populate(&s))
+		assert.Equal(t, [2]int{1, 0}, s)
+	})
+
+	t.Run("empty collection with first element overridden", func(t *testing.T) {
+		p := NewStaticProvider(map[string]interface{}{"a": []int{}, "a.0": 1})
+		var s [2]int
+		require.NoError(t, p.Get("a").Populate(&s))
+		assert.Equal(t, [2]int{1, 0}, s)
+	})
+
+	t.Run("collection with second element overridden", func(t *testing.T) {
+		p := NewStaticProvider(map[string]interface{}{"a": []int{0, 1, 2}, "a.1": 3})
+		var s [2]int
+		require.NoError(t, p.Get("a").Populate(&s))
+		assert.Equal(t, [2]int{0, 3}, s)
+	})
+
+	t.Run("collection with an extra element added", func(t *testing.T) {
+		p := NewStaticProvider(map[string]interface{}{"a": []int{0, 1, 2}, "a.3": 3})
+		var s [4]int
+		require.NoError(t, p.Get("a").Populate(&s))
+		assert.Equal(t, [4]int{0, 1, 2, 3}, s)
+	})
+
+	t.Run("collection with a nil element inside", func(t *testing.T) {
+		p := NewStaticProvider(map[string]interface{}{"a": []int{0, 1, 2}, "a.1": nil})
+		var s [3]int
+		require.NoError(t, p.Get("a").Populate(&s))
+		assert.Equal(t, [3]int{0, 0, 2}, s)
+	})
+
+	t.Run("collection error unmarshalable elements", func(t *testing.T) {
+		p := NewYAMLProviderFromBytes([]byte(`
+a:
+- protagonist: Scrooge
+  pilot: LaunchpadMcQuack
+`))
+		var s [2]duckTales
+		err := p.Get("a").Populate(&s)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `for key "a.1.Protagonist": Unknown character:`)
+	})
 }

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -1393,6 +1393,23 @@ func TestSliceElementInDifferentPositions(t *testing.T) {
 		require.NoError(t, p.Get("a").Populate(&s))
 		assert.Equal(t, []int{0, 0, 2}, s)
 	})
+
+
+	t.Run("default value in the middle", func(t *testing.T) {
+		type Inner struct {
+			Set bool `yaml:"set" default:"true"`
+		}
+
+		p := NewYAMLProviderFromBytes([]byte(`
+a:
+- set: true
+- get: something
+- set: false`))
+
+		var a []Inner
+		require.NoError(t, p.Get("a").Populate(&a))
+		assert.Equal(t, []Inner{{Set:true}, {Set:true}, {Set: false}}, a)
+	})
 }
 
 func TestArrayElementInDifferentPositions(t *testing.T) {
@@ -1457,5 +1474,23 @@ a:
 		err := p.Get("a").Populate(&s)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), `for key "a.1.Protagonist": Unknown character:`)
+	})
+
+	t.Run("default value in the middle", func(t *testing.T) {
+		type Inner struct {
+			Set bool `yaml:"set" default:"true"`
+		}
+
+		p := NewYAMLProviderFromBytes([]byte(`
+a:
+- set: true
+- get: something
+- get: something
+- set: false
+a.2.set: false`))
+
+		var a [4]Inner
+		require.NoError(t, p.Get("a").Populate(&a))
+		assert.Equal(t, [4]Inner{{Set:true}, {Set: true}, {Set: false}, {Set: false}}, a)
 	})
 }


### PR DESCRIPTION
We have several bugs related to collections:

1. [Populate doesn't fail on malformed data](https://github.com/uber-go/config/issues/21)
1. [Command line is implemented via maps, so slices aliases can't be used for unmarshaling data](https://github.com/uber-go/config/issues/29).
1. Populate for slices iterates only until a first nil element, even if a collection is larger.
1. ValueType doesn't differentiate between slices and arrays - it is removed, one can simply rely on `reflect.Kind(v.Value())`

I've merged all the above bugs into 1 PR, because it is harder to fix these issues atomically(it would require more code changes)

@akshayjshah and @abhinav I understand, that you are not familiar with the code base, so it is mostly FYI.