### PR TITLE
Skip inappropriate types instead of reporting errors on them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## v1.0.0-rc2 (unreleased)
 
 - **[Breaking]** `ValueType` and `GetType` functionality is removed in favor of using
-  `reflect.Kind`
+  `reflect.Kind`.
+- Skip populating function and value types instead of reporting errors.
 
 ## v1.0.0-rc1 (26 Jun 2017)
 

--- a/decoder.go
+++ b/decoder.go
@@ -623,6 +623,10 @@ func (d *decoder) unmarshal(name string, value reflect.Value, def string) error 
 	switch value.Kind() {
 	case reflect.Invalid:
 		return fmt.Errorf("invalid value type for key %s", name)
+
+	// Permissive decoding: skip Chan/Func fields, instead of returning an
+	// error. We don't have schemas and the caller probably has a big
+	// aggregate struct and these fields will be set up separately later.
 	case reflect.Chan, reflect.Func:
 		return nil
 	case reflect.Ptr:

--- a/decoder.go
+++ b/decoder.go
@@ -621,8 +621,10 @@ func (d *decoder) unmarshal(name string, value reflect.Value, def string) error 
 
 	// Try to unmarshal each type separately.
 	switch value.Kind() {
-	case reflect.Invalid, reflect.Chan, reflect.Func:
+	case reflect.Invalid:
 		return fmt.Errorf("invalid value type for key %s", name)
+	case reflect.Chan, reflect.Func:
+		return nil
 	case reflect.Ptr:
 		return d.pointer(name, value, def)
 	case reflect.Struct:

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -1176,14 +1176,19 @@ func (y *yamlUnmarshal) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-func TestInvalidPopulate(t *testing.T) {
+func TestPopulateNotAppropriateTypes(t *testing.T) {
 	t.Parallel()
 
 	p := newValueProvider(nil)
-	var v chan int
-	err := p.Get(Root).Populate(&v)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid value type for key")
+	t.Run("channel", func(t *testing.T) {
+		v := make(chan int)
+		require.NoError(t, p.Get(Root).Populate(&v))
+	})
+
+	t.Run("func", func(t *testing.T) {
+		var f func()
+		require.NoError(t, p.Get(Root).Populate(&f))
+	})
 }
 
 type alwaysBlueYAML struct{}


### PR DESCRIPTION
Sometimes configuration structs can contain public fields that are channels/functions that don't implement TextUnmarshaller/UnmarshalYAML interfaces. They are are supposed to be field manually/by another function and errors break this flow. We should silently skip them instead, an example is [json.Unmarshal](https://golang.org/pkg/encoding/json/#Unmarshal)