### PR TITLE
Run tests twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ install:
 
 .PHONY: test
 test:
-	go test -race $(PACKAGES)
+	go test -race $(PACKAGES) -count 2
 
 .PHONY: ci
 ci: SHELL := /bin/bash
 ci:
-	go test -race $(PACKAGES) -coverprofile=coverage.txt -covermode=atomic
+	go test -race $(PACKAGES) -coverprofile=coverage.txt -covermode=atomic -count 2
 	bash <(curl -s https://codecov.io/bash)
 
 .PHONY: license


### PR DESCRIPTION
Most of the tests already run in parallel, but I also don't want tests to have any saved records in global variables. Running them twice will make sure that everything is cleaned up correctly.