### PR TITLE
Make Value.Timestamp private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **[Breaking]** `ValueType` and `GetType` functionality is removed in favor of using
   `reflect.Kind`.
 - Skip populating function and value types instead of reporting errors.
+- **[Breaking]** `Value.Timestamp` is private, use Value.LastUpdated instead.
 
 ## v1.0.0-rc1 (26 Jun 2017)
 

--- a/value.go
+++ b/value.go
@@ -38,7 +38,7 @@ type Value struct {
 	value        interface{}
 	found        bool
 	defaultValue interface{}
-	Timestamp    time.Time
+	timestamp    time.Time
 }
 
 // NewValue creates a configuration value from a provider and a set
@@ -59,9 +59,9 @@ func NewValue(
 	}
 
 	if timestamp == nil {
-		cv.Timestamp = time.Now()
+		cv.timestamp = time.Now()
 	} else {
-		cv.Timestamp = *timestamp
+		cv.timestamp = *timestamp
 	}
 	return cv
 }
@@ -79,7 +79,7 @@ func (cv Value) LastUpdated() time.Time {
 	if !cv.HasValue() {
 		return time.Time{} // zero value if never updated?
 	}
-	return cv.Timestamp
+	return cv.timestamp
 }
 
 // WithDefault sets the default value that can be overridden


### PR DESCRIPTION
There is no particular reason for a `Timestamp` to be a public field, but keeping everything else private. With this change all access to `Value`'s internal fields will be done via methods.