### PR TITLE
Use semantic version paths for yaml and validator packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   `reflect.Kind`.
 - Skip populating function and value types instead of reporting errors.
 - **[Breaking]** `Value.Timestamp` is private, use Value.LastUpdated instead.
+- **[Breaking]** Use semantic version paths for yaml and validator packages.
 
 ## v1.0.0-rc1 (26 Jun 2017)
 

--- a/decoder.go
+++ b/decoder.go
@@ -29,9 +29,9 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/go-validator/validator"
-	"github.com/go-yaml/yaml"
 	"github.com/pkg/errors"
+	"gopkg.in/validator.v2"
+	"gopkg.in/yaml.v2"
 )
 
 type fieldInfo struct {

--- a/glide.lock
+++ b/glide.lock
@@ -1,21 +1,21 @@
-hash: a89d01a7466ea58f6fa65231986881a9eb773550a1f591272d415b7cb54b5142
-updated: 2017-06-01T16:54:47.612952816-07:00
+hash: 7d09e842bb5d045f9d3e59e4c2755a9b248b0b9622bc2c168bcfc3a84a9b846c
+updated: 2017-07-18T16:28:34.042449923-07:00
 imports:
-- name: github.com/go-validator/validator
-  version: 07ffaad256c8e957050ad83d6472eb97d785013d
-- name: github.com/go-yaml/yaml
-  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/spf13/pflag
   version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
+- name: gopkg.in/validator.v2
+  version: 07ffaad256c8e957050ad83d6472eb97d785013d
+- name: gopkg.in/yaml.v2
+  version: 3b4ad1db5b2a649883ff3782f5f9f6fb52be71af
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/google/gofuzz
-  version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
+  version: 24818f796faf91cd76ec7bddd72458fbced7a6c1
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,12 +1,10 @@
 package: go.uber.org/config
 import:
-- package: github.com/go-validator/validator
-  version: v2
+- package: gopkg.in/validator.v2
+- package: gopkg.in/yaml.v2
 - package: github.com/spf13/pflag
 - package: github.com/pkg/errors
   version: ~0.8.0
-- package: github.com/go-yaml/yaml
-  version: v2
 testImport:
 - package: github.com/google/gofuzz
 - package: github.com/stretchr/testify

--- a/static_provider.go
+++ b/static_provider.go
@@ -25,7 +25,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/go-yaml/yaml"
+	"gopkg.in/yaml.v2"
 )
 
 type staticProvider struct {

--- a/yaml.go
+++ b/yaml.go
@@ -30,8 +30,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-yaml/yaml"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 )
 
 type yamlConfigProvider struct {


### PR DESCRIPTION
Most of the projects are using semantic version paths(e.g. yarpc, dosa, tally),
so it is better to be in sync with them.