### PR TITLE
Let user to skip loading command line provider via  parameter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   `reflect.Kind`.
 - Skip populating function and value types instead of reporting errors.
 - **[Breaking]** `Value.Timestamp` is private, use Value.LastUpdated instead.
+- Let user to skip loading command line provider via `commandline` parameter.
 
 ## v1.0.0-rc1 (26 Jun 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Skip populating function and value types instead of reporting errors.
 - **[Breaking]** `Value.Timestamp` is private, use Value.LastUpdated instead.
 - **[Breaking]** Use semantic version paths for yaml and validator packages.
-- Let user to skip loading command line provider via `commandline` parameter.
+- Let user to skip loading command line provider via `commandLine` parameter.
 
 ## v1.0.0-rc1 (26 Jun 2017)
 

--- a/config.go
+++ b/config.go
@@ -43,7 +43,7 @@ type FileInfo struct {
 //  ./config/${ENVIRONMENT}.yaml
 //  ./config/secrets.yaml
 // The provider is also amended with a command line provider that reads
-// a roles flag.
+// a roles flag. It can be skipped by seting commandline value to false.
 func LoadDefaults() (Provider, error) {
 	env := "development"
 	if val, ok := os.LookupEnv("ENVIRONMENT"); ok {
@@ -61,6 +61,10 @@ func LoadDefaults() (Provider, error) {
 
 	if err != nil {
 		return nil, err
+	}
+
+	if !p.Get("commandline").WithDefault(true).AsBool() {
+		return p, nil
 	}
 
 	// Load commandLineProvider

--- a/config.go
+++ b/config.go
@@ -43,10 +43,10 @@ type FileInfo struct {
 //  ./config/${ENVIRONMENT}.yaml
 //  ./config/secrets.yaml
 // The provider is also amended with a command line provider that reads
-// a roles flag. It can be skipped by seting commandline value to false
+// a roles flag. It can be skipped by seting commandLine value to false
 // at the root level of config file:
 //
-//  commandline: false
+//  commandLine: false
 func LoadDefaults() (Provider, error) {
 	env := "development"
 	if val, ok := os.LookupEnv("ENVIRONMENT"); ok {
@@ -66,7 +66,7 @@ func LoadDefaults() (Provider, error) {
 		return nil, err
 	}
 
-	if !p.Get("commandline").WithDefault(true).AsBool() {
+	if !p.Get("commandLine").WithDefault(true).AsBool() {
 		return p, nil
 	}
 

--- a/config.go
+++ b/config.go
@@ -38,13 +38,16 @@ type FileInfo struct {
 	Interpolate bool   // Interpolate contents?
 }
 
-// LoadDefaults returns a default set of configuration files:
+// LoadDefaults returns a default provider from a set of configuration
+// files:
 //  ./config/base.yaml
 //  ./config/${ENVIRONMENT}.yaml
 //  ./config/secrets.yaml
-// The provider is also amended with a command line provider that reads
-// a roles flag. It can be skipped by seting commandLine value to false
-// at the root level of config file:
+//
+// The result configuration is merged with a command line provider that
+// reads a roles flag. If it is not a desired behavior, the command line
+// provider can be skipped by seting commandLine value to false
+// at the root level of any of the config files:
 //
 //  commandLine: false
 func LoadDefaults() (Provider, error) {

--- a/config.go
+++ b/config.go
@@ -43,7 +43,10 @@ type FileInfo struct {
 //  ./config/${ENVIRONMENT}.yaml
 //  ./config/secrets.yaml
 // The provider is also amended with a command line provider that reads
-// a roles flag. It can be skipped by seting commandline value to false.
+// a roles flag. It can be skipped by seting commandline value to false
+// at the root level of config file:
+//
+//  commandline: false
 func LoadDefaults() (Provider, error) {
 	env := "development"
 	if val, ok := os.LookupEnv("ENVIRONMENT"); ok {

--- a/config_test.go
+++ b/config_test.go
@@ -106,7 +106,7 @@ func TestDefaultLoad(t *testing.T) {
 	defer func() { assert.NoError(os.Remove(base.Name())) }()
 
 	defer setEnv("PORT", "80")()
-	base.WriteString("source: base\ninterpolated: ${PORT:17}\n")
+	base.WriteString("commandline: false\nsource: base\ninterpolated: ${PORT:17}\n")
 	base.Close()
 
 	// Setup development.yaml
@@ -131,7 +131,7 @@ func TestDefaultLoad(t *testing.T) {
 	assert.Equal(80, p.Get("interpolated").AsInt())
 	assert.Equal("loaded", p.Get("development").AsString())
 	assert.Equal("${password:1111}", p.Get("secret").AsString())
-	assert.Empty(p.Get("roles").Value())
+	assert.False(p.Get("roles").HasValue())
 }
 
 func TestDefaultLoadMultipleTimes(t *testing.T) {
@@ -156,6 +156,7 @@ func TestDefaultLoadMultipleTimes(t *testing.T) {
 	assert.Equal(3, len(val))
 	assert.Equal("base", p.Get("source").AsString())
 	assert.Equal(80, p.Get("interpolated").AsInt())
+	assert.True(p.Get("roles").HasValue())
 	assert.Empty(p.Get("roles").Value())
 }
 


### PR DESCRIPTION
Right now there is no easy way of skipping command line provider which can conflict with another command line libraries. Instead of requiring user to set up all the flags in the `pflag.CommandLine` variable we'll read `commandline` value from previously loaded providers(yaml files).