### PR TITLE
Make YAML constructors from io.ReadCloser internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **[Breaking]** Try and As conversion helpers are removed in favor of using
   other cast libraries.
 - **[Breaking]** Removed Load* functions.
+- **[Breaking]** Removed NewYAMLProviderFromReader* functions.
 
 ## v1.0.0-rc1 (26 Jun 2017)
 

--- a/config_test.go
+++ b/config_test.go
@@ -357,7 +357,7 @@ rpc:
 		return "4324", true
 	}
 
-	p, err := NewYAMLProviderFromReaderWithExpand(
+	p, err := newYAMLProviderFromReaderWithExpand(
 		lookup,
 		ioutil.NopCloser(bytes.NewBufferString(rpc)))
 

--- a/static_provider.go
+++ b/static_provider.go
@@ -41,7 +41,7 @@ func NewStaticProvider(data interface{}) (Provider, error) {
 		return nil, err
 	}
 
-	p, err := NewYAMLProviderFromReader(c)
+	p, err := newYAMLProviderFromReader(c)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func NewStaticProviderWithExpand(
 		return nil, err
 	}
 
-	p, err := NewYAMLProviderFromReaderWithExpand(mapping, reader)
+	p, err := newYAMLProviderFromReaderWithExpand(mapping, reader)
 	if err != nil {
 		return nil, err
 	}

--- a/static_provider_test.go
+++ b/static_provider_test.go
@@ -351,7 +351,7 @@ func TestInterpolatedBool(t *testing.T) {
 		return "", false
 	}
 
-	p, err := NewYAMLProviderFromReaderWithExpand(
+	p, err := newYAMLProviderFromReaderWithExpand(
 		f,
 		ioutil.NopCloser(strings.NewReader("val: ${interpolate:false}")))
 

--- a/yaml.go
+++ b/yaml.go
@@ -150,12 +150,12 @@ func NewYAMLProviderWithExpand(mapping func(string) (string, bool), files ...str
 		return nil, err
 	}
 
-	return NewYAMLProviderFromReaderWithExpand(mapping, readers...)
+	return newYAMLProviderFromReaderWithExpand(mapping, readers...)
 }
 
 // NewYAMLProviderFromReader creates a configuration provider from a list of io.ReadClosers.
 // As above, all the objects are going to be merged and arrays/values overridden in the order of the files.
-func NewYAMLProviderFromReader(readers ...io.ReadCloser) (Provider, error) {
+func newYAMLProviderFromReader(readers ...io.ReadCloser) (Provider, error) {
 	p, err := newYAMLProviderCore(readers...)
 	if err != nil {
 		return nil, err
@@ -167,7 +167,7 @@ func NewYAMLProviderFromReader(readers ...io.ReadCloser) (Provider, error) {
 // NewYAMLProviderFromReaderWithExpand creates a configuration provider from
 // a list of `io.ReadClosers and uses the mapping function to expand values
 // in the underlying provider.
-func NewYAMLProviderFromReaderWithExpand(
+func newYAMLProviderFromReaderWithExpand(
 	mapping func(string) (string, bool),
 	readers ...io.ReadCloser) (Provider, error) {
 	p, err := newYAMLProviderCore(readers...)

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -76,7 +76,7 @@ module:
   fake:
     number: ${FAKE_NUMBER:321}`)
 
-	p, err := NewYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
+	p, err := newYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
 	require.NoError(t, err, "Can't create a YAML provider")
 	require.Equal(t, "321", p.Get("module.fake.number").String())
 
@@ -92,7 +92,7 @@ name: some name here
 email: ${EMAIL_ADDRESS}`)
 
 	f := func(string) (string, bool) { return "", false }
-	_, err := NewYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
+	_, err := newYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `default is empty for "EMAIL_ADDRESS"`)
 }
@@ -105,7 +105,7 @@ name: some name here
 telephone: ${SUPPORT_TEL:}`)
 
 	f := func(string) (string, bool) { return "", false }
-	_, err := NewYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
+	_, err := newYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `default is empty for "SUPPORT_TEL" (use "" for empty string)`)
@@ -119,7 +119,7 @@ func TestYAMLEnvInterpolationWithColon(t *testing.T) {
 		return "", false
 	}
 
-	p, err := NewYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
+	p, err := newYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
 	require.NoError(t, err, "Can't create a YAML provider")
 
 	require.Equal(t, "this:is:my:value", p.Get("fullValue").String())
@@ -133,7 +133,7 @@ name: ${APP_NAME:my shiny app}
 fullTel: 1-800-LOLZ${TELEPHONE_EXTENSION:""}`)
 
 	f := func(string) (string, bool) { return "", false }
-	p, err := NewYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
+	p, err := newYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
 	require.NoError(t, err, "Can't create a YAML provider")
 
 	require.Equal(t, "my shiny app", p.Get("name").String())
@@ -218,7 +218,7 @@ func TestNewYAMLProviderFromReader(t *testing.T) {
 	t.Parallel()
 
 	buff := bytes.NewBuffer([]byte(_yamlConfig1))
-	provider, err := NewYAMLProviderFromReader(ioutil.NopCloser(buff))
+	provider, err := newYAMLProviderFromReader(ioutil.NopCloser(buff))
 	require.NoError(t, err, "Can't create a YAML provider")
 
 	cs := &configStruct{}
@@ -1194,7 +1194,7 @@ func TestYAMLEnvInterpolationValueMissing(t *testing.T) {
 	cfg := strings.NewReader(`name:`)
 
 	f := func(string) (string, bool) { return "", false }
-	p, err := NewYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
+	p, err := newYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
 	require.NoError(t, err, "Can't create a YAML provider")
 	assert.Equal(t, nil, p.Get("name").Value())
 }
@@ -1209,7 +1209,7 @@ func TestYAMLEnvInterpolationValueConversion(t *testing.T) {
 		return "3", true
 	}
 
-	p, err := NewYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
+	p, err := newYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
 	require.NoError(t, err, "Can't create a YAML provider")
 
 	assert.Equal(t, "3", p.Get("number").String())
@@ -1722,7 +1722,7 @@ func TestMergeErrorsFromReaders(t *testing.T) {
 		dev := ioutil.NopCloser(strings.NewReader(`a:
   b: c`))
 
-		_, err := NewYAMLProviderFromReader(base, dev)
+		_, err := newYAMLProviderFromReader(base, dev)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "can't merge map")
 	})
@@ -1735,7 +1735,7 @@ func TestMergeErrorsFromReaders(t *testing.T) {
 		dev := ioutil.NopCloser(strings.NewReader(`a:
   b: c`))
 
-		_, err := NewYAMLProviderFromReaderWithExpand(expand, base, dev)
+		_, err := newYAMLProviderFromReaderWithExpand(expand, base, dev)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "can't merge map")
 	})
@@ -1772,7 +1772,7 @@ func TestMergeErrorsFromFiles(t *testing.T) {
 		d, err := ioutil.ReadFile(dev.Name())
 		require.NoError(t, err, "Can't read dev file")
 
-		_, err = NewYAMLProviderFromReader(
+		_, err = newYAMLProviderFromReader(
 			ioutil.NopCloser(bytes.NewBuffer(b)),
 			ioutil.NopCloser(bytes.NewBuffer(d)))
 
@@ -1797,7 +1797,7 @@ func TestMergeErrorsFromFiles(t *testing.T) {
 
 		expand := func(string) (string, bool) { return "", false }
 
-		_, err = NewYAMLProviderFromReaderWithExpand(
+		_, err = newYAMLProviderFromReaderWithExpand(
 			expand,
 			ioutil.NopCloser(bytes.NewBuffer(b)),
 			ioutil.NopCloser(bytes.NewBuffer(d)))


### PR DESCRIPTION
These constructors are not used by anyone internally and it is much easier either to load a provider from file or use a static provider for testing.