### PR TITLE
Remove IsDefault method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **[Breaking]** `Value.WithDefault` returns an error when a default can't be used.
 - **[Breaking]** Try and As conversion helpers are removed in favor of using
   other cast libraries.
+- **[Breaking]** Removed `Value.IsDefault` method.
 
 ## v1.0.0-rc1 (26 Jun 2017)
 

--- a/config_test.go
+++ b/config_test.go
@@ -238,7 +238,6 @@ func TestScopedAccess(t *testing.T) {
 
 	assert.True(t, v1.HasValue())
 	assert.Equal(t, 111, v1.Value())
-	assert.True(t, v2.IsDefault())
 	assert.True(t, v2.HasValue())
 	assert.Equal(t, v2.String(), "nope")
 }

--- a/provider_group.go
+++ b/provider_group.go
@@ -54,7 +54,7 @@ func (p providerGroup) Get(key string) Value {
 	var res interface{}
 	found := false
 	for _, provider := range p.providers {
-		if val := provider.Get(key); val.HasValue() && !val.IsDefault() {
+		if val := provider.Get(key); val.HasValue() {
 			tmp, err := mergeMaps(res, val.value)
 			if err != nil {
 				return NewValue(p, key, nil, false)

--- a/static_provider_test.go
+++ b/static_provider_test.go
@@ -62,7 +62,6 @@ func TestStaticProvider_WithData(t *testing.T) {
 
 	val := p.Get("hello")
 	assert.True(t, val.HasValue())
-	assert.False(t, val.IsDefault())
 	assert.Equal(t, "world", val.String())
 }
 

--- a/value.go
+++ b/value.go
@@ -32,12 +32,11 @@ var _typeOfString = reflect.TypeOf("string")
 
 // A Value holds the value of a configuration
 type Value struct {
-	root         Provider
-	provider     Provider
-	key          string
-	value        interface{}
-	found        bool
-	defaultValue interface{}
+	root     Provider
+	provider Provider
+	key      string
+	value    interface{}
+	found    bool
 }
 
 // NewValue creates a configuration value from a provider and a set
@@ -49,11 +48,10 @@ func NewValue(
 	found bool,
 ) Value {
 	return Value{
-		provider:     provider,
-		key:          key,
-		value:        value,
-		defaultValue: nil,
-		found:        found,
+		provider: provider,
+		key:      key,
+		value:    value,
+		found:    found,
 	}
 }
 
@@ -68,14 +66,13 @@ func (cv Value) Source() string {
 // WithDefault sets the default value that can be overridden
 // by providers with a highger priority.
 func (cv Value) WithDefault(value interface{}) (Value, error) {
-	cv.defaultValue = value
 	p, err := NewStaticProvider(map[string]interface{}{cv.key: value})
 	if err != nil {
 		return cv, err
 	}
 
-	cv.root = NewProviderGroup("withDefault", p, cv.provider)
-	return cv, nil
+	g := NewProviderGroup("withDefault", p, cv.provider)
+	return g.Get(cv.key), nil
 }
 
 // String prints out underlying value in Value with fmt.Sprint.
@@ -83,24 +80,14 @@ func (cv Value) String() string {
 	return fmt.Sprint(cv.Value())
 }
 
-// IsDefault returns whether the return value is the default.
-func (cv Value) IsDefault() bool {
-	// TODO(ai) what should the semantics be if the provider has a value that's
-	// the same as the default value?
-	return !cv.found && cv.defaultValue != nil
-}
-
 // HasValue returns whether the configuration has a value that can be used.
 func (cv Value) HasValue() bool {
-	return cv.found || cv.IsDefault()
+	return cv.found
 }
 
 // Value returns the underlying configuration's value.
 func (cv Value) Value() interface{} {
-	if cv.found {
-		return cv.value
-	}
-	return cv.defaultValue
+	return cv.value
 }
 
 // Get returns a value scoped in the current value.


### PR DESCRIPTION
There is no need to have an extra semantic of checking if a value is a default one.
User can make a new value with extra defaults via `Value.WithDefault`, but checking
for a default is very cumbersome: how can we differentiate a zero value and
a default value that is a zero value for a type.