### PR TITLE
Refresh stickers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,4 @@
-# Config
-:fishing_pole_and_fish:
-[![GoDoc][doc-img]][doc]
-[![Build Status][ci-img]][ci]
-[![Coverage Status][cov-img]][cov]
-[![Report Card][report-card-img]][report-card]
+# :fishing_pole_and_fish: config [![GoDoc][doc-img]][doc] [![GitHub release][release-img]][release] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Report Card][report-card-img]][report-card]
 
 Package `config` allows users to:
 
@@ -24,16 +19,17 @@ This library is `v1` and follows [SemVer](http://semver.org/) strictly.
 
 No breaking changes will be made to exported APIs before `v2.0.0`.
 
-## License
-
-[MIT](LICENSE.txt)
-
+[doc-img]: http://img.shields.io/badge/GoDoc-Reference-blue.svg
 [doc]: https://godoc.org/go.uber.org/config
-[doc-img]: https://godoc.org/go.uber.org/config?status.svg
-[ci]: https://travis-ci.org/uber-go/config
-[ci-img]: https://travis-ci.org/uber-go/config.svg?branch=master
+
+[release-img]: https://img.shields.io/github/release/uber-go/config.svg
+[release]: https://github.com/uber-go/config/releases
+
+[ci-img]: https://img.shields.io/travis/uber-go/config/master.svg
+[ci]: https://travis-ci.org/uber-go/config/branches
+
+[cov-img]: https://codecov.io/gh/uber-go/config/branch/master/graph/badge.svg
+[cov]: https://codecov.io/gh/uber-go/config/branch/master
+
 [report-card]: https://goreportcard.com/report/github.com/uber-go/config
 [report-card-img]: https://goreportcard.com/badge/github.com/uber-go/config
-[cov]: https://codecov.io/gh/uber-go/config/branch/master
-[cov-img]: https://codecov.io/gh/uber-go/config/branch/master/graph/badge.svg
-


### PR DESCRIPTION
* Add latest release sticker
* Match other repo's readme structure
* Remove license section from readme - Github has 1st-class support to show this on the repo page (see top right)