### PR TITLE
Fix unmarshal text on missing value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## v1.0.1 (unreleased)
+## v1.0.1 (2017-08-04)
 
-- No changes yet
+- Fixed unmarshal text on missing value.
 
-## v1.0.0 (07-31-2017)
+## v1.0.0 (2017-07-31)
 
 First stable release: no breaking changes will be made in the 1.x series.
 
@@ -23,6 +23,6 @@ First stable release: no breaking changes will be made in the 1.x series.
 - **[Breaking]** Unexport NewYAMLProviderFromReader* functions.
 - **[Breaking]** `NewProviderGroup` returns an error.
 
-## v1.0.0-rc1 (06-26-2017)
+## v1.0.0-rc1 (2017-06-26)
 
 - **[Breaking]** `Provider` interface was trimmed down to 2 methods: `Name` and `Get`

--- a/decoder.go
+++ b/decoder.go
@@ -564,6 +564,8 @@ func (d *decoder) tryUnmarshalers(key string, value reflect.Value, def string) (
 		// check if we need to use custom defaults
 		if v.HasValue() {
 			def = v.String()
+		} else {
+			return true, nil
 		}
 
 		return true, errorWithKey(t.UnmarshalText([]byte(def)), key)

--- a/static_provider_test.go
+++ b/static_provider_test.go
@@ -404,3 +404,12 @@ func TestStaticProviderConstructorErrors(t *testing.T) {
 		assert.Contains(t, err.Error(), `default is empty for "Email"`)
 	})
 }
+
+func TestTextUnmarshalerOnMissingValue(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewStaticProvider(nil)
+	require.NoError(t, err)
+	ds := duckTales{}
+	require.NoError(t, p.Get(Root).Populate(&ds))
+}


### PR DESCRIPTION
We invoke `TextUnmarshaler.UnmarshalText` even if a value is missing from a config, which will lead to errors like https://github.com/uber-go/config/issues/55. We should keep a zero initialized value instead of unmarshalling an empty string.