### PR TITLE
Perform variable expansion using text.Transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## v1.1.0 (not released yet)
 
-- No changes yet.
+- Expand functions transform a special sequence $$ to literal $.
+- The underlying objects encapsulated by config.Value types will now
+  have the types determined by the YAML unmarshaller regardless of
+  whether expansion was performed or not.
 
 ## v1.0.2 (2017-08-17)
 

--- a/expand.go
+++ b/expand.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"bytes"
+
+	"golang.org/x/text/transform"
+)
+
+// expandTransformer implements transform.Transformer
+type expandTransformer struct {
+	transform.NopResetter
+	expand func(string) (string, error)
+}
+
+// First char of shell variable may be [a-zA-Z_]
+func isShellNameFirstChar(c byte) bool {
+	return c == '_' ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z')
+}
+
+// Char's after the first of shell variable may be [a-zA-Z0-9_]
+func isShellNameChar(c byte) bool {
+	return c == '_' ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9')
+}
+
+// bytesIndexCFunc returns the index of the byte for which the
+// complement of the supplied function is true
+func bytesIndexCFunc(buf []byte, f func(b byte) bool) int {
+	for i, b := range buf {
+		if !f(b) {
+			return i
+		}
+	}
+	return -1
+}
+
+// Transform expands shell-like sequences like $foo and ${foo} using
+// the configured expand function.  The sequence '$$' is replaced with
+// a literal '$'.
+func (e *expandTransformer) Transform(dst, src []byte, atEOF bool) (int, int, error) {
+	var srcPos int
+	var dstPos int
+
+	for srcPos < len(src) {
+
+		if dstPos == len(dst) {
+			return dstPos, srcPos, transform.ErrShortDst
+		}
+
+		end := bytes.IndexByte(src[srcPos:], '$')
+
+		if end == -1 {
+			// src does not contain '$', copy into dst
+			cnt := copy(dst[dstPos:], src[srcPos:])
+			srcPos += cnt
+			dstPos += cnt
+			continue
+		} else if end > 0 {
+			// copy chars preceding '$' from src to dst
+			cnt := copy(dst[dstPos:], src[srcPos:srcPos+end])
+			srcPos += cnt
+			dstPos += cnt
+
+			if dstPos == len(dst) {
+				return dstPos, srcPos, transform.ErrShortDst
+			}
+		}
+
+		// src[srcPos] now points to '$', dstPos < len(dst)
+
+		// If we're at the end of src, but we found a starting
+		// token, return ErrShortSrc, unless we're also at EOF,
+		// in which case just copy it dst.
+		if srcPos+1 == len(src) {
+			if atEOF {
+				dst[dstPos] = src[srcPos]
+				srcPos++
+				dstPos++
+				continue
+			}
+			return dstPos, srcPos, transform.ErrShortSrc
+		}
+
+		// At this point we know that src[srcPos+1] is populated.
+
+		// If this token sequence represents the special '$$'
+		// sequence, emit a '$' into dst.
+		if src[srcPos+1] == '$' {
+			dst[dstPos] = src[srcPos]
+			srcPos += 2
+			dstPos++
+			continue
+		}
+
+		var token []byte
+		var tokenEnd int
+
+		// Start of bracketed token ${foo}
+		if src[srcPos+1] == '{' {
+			end := bytes.IndexByte(src[srcPos+2:], '}')
+			if end == -1 {
+				if atEOF {
+					// No closing bracket and we're at
+					// EOF, so it's not a valid bracket
+					// expression.
+					if len(dst[dstPos:]) <
+						len(src[srcPos:]) {
+						return dstPos, srcPos,
+							transform.ErrShortDst
+					}
+
+					cnt := copy(dst[dstPos:], src[srcPos:])
+					srcPos += cnt
+					dstPos += cnt
+					continue
+				}
+
+				// Otherwise, we need more bytes in src
+				return dstPos, srcPos, transform.ErrShortSrc
+			}
+
+			// Set tokenEnd so it points to the byte
+			// immediately after the closing '}'
+			tokenEnd = end + srcPos + 3
+
+			token = src[srcPos+2 : tokenEnd-1]
+		} else { // Else start of non-bracketed token $foo
+			if !isShellNameFirstChar(src[srcPos+1]) {
+				// If it doesn't conform to the naming
+				// rules for shell variables, do not
+				// try to expand, just copy to dst.
+				dst[dstPos] = src[srcPos]
+				srcPos++
+				dstPos++
+				continue
+			}
+
+			end := bytesIndexCFunc(src[srcPos+2:], isShellNameChar)
+
+			if end == -1 {
+				// Reached the end of src without finding
+				// end of shell variable
+				if !atEOF {
+					// We need more bytes in src
+					return dstPos, srcPos,
+						transform.ErrShortSrc
+				}
+				tokenEnd = len(src)
+			} else {
+				// Set tokenEnd so it points to the byte
+				// immediately after the token
+				tokenEnd = end + srcPos + 2
+			}
+
+			token = src[srcPos+1 : tokenEnd]
+		}
+
+		replacement, err := e.expand(string(token))
+		if err != nil {
+			return dstPos, srcPos, err
+		}
+
+		if len(dst[dstPos:]) < len(replacement) {
+			return dstPos, srcPos, transform.ErrShortDst
+		}
+
+		cnt := copy(dst[dstPos:], replacement)
+		srcPos = tokenEnd
+		dstPos += cnt
+	}
+
+	return dstPos, srcPos, nil
+}

--- a/expand_test.go
+++ b/expand_test.go
@@ -1,0 +1,295 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/transform"
+)
+
+// Size of buffer used by the transform package.
+const transformBufSize = 4096
+
+const orig = `This is a $t3sT$. $$ This is a $$test.
+	This is not a valid $0ne.  But this one $i5_@_valid-one.
+	$$$$$$$
+${parti`
+
+const expected = `This is a test$. $ This is a $test.
+	This is not a valid $0ne.  But this one is @_valid-one.
+	$$$$
+${parti`
+
+const ends_in_dollar = `There is a dollar at the end$`
+const ends_in_ddollar = `There is a dollar at the end$$`
+const many_dollars_orig = `$$$$$$$`
+const many_dollars_expect = `$$$$`
+const ends_in_var = `There is a test at the end: $t3sT`
+const ends_in_var_expect = `There is a test at the end: test`
+
+type oneByteReader struct {
+	r io.Reader
+}
+
+func (e *oneByteReader) Read(buf []byte) (n int, err error) {
+	var b [1]byte
+
+	if len(buf) > 0 {
+		n, err = e.r.Read(b[:])
+		buf[0] = b[0]
+	}
+
+	return
+}
+
+type bufReader struct {
+	buf    []byte
+	offset int
+}
+
+// Similar to a bytes.Reader except this Reader returns EOF in the same
+// Read that reads the end of the buffer.
+func (e *bufReader) Read(buf []byte) (int, error) {
+	var err error
+	n := copy(buf, e.buf[e.offset:])
+	e.offset += n
+	if e.offset == len(e.buf) {
+		err = io.EOF
+	}
+	return n, err
+}
+
+func TestExpander(t *testing.T) {
+	t.Parallel()
+
+	r := bytes.NewReader([]byte(orig))
+
+	expand_func := func(s string) (string, error) {
+		switch s {
+		case "t3sT":
+			return "test", nil
+		case "i5_":
+			return "is ", nil
+		}
+
+		return "NOMATCH", errors.New("No Match")
+	}
+
+	// Parse whole string
+	tr := transform.NewReader(r, &expandTransformer{expand: expand_func})
+	actual, err := ioutil.ReadAll(tr)
+	require.NoError(t, err)
+	assert.Exactly(t, expected, string(actual))
+
+	_, err = r.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+
+	// Partial parse
+	var partial [11]byte
+	tr = transform.NewReader(r, &expandTransformer{expand: expand_func})
+	n, err := tr.Read(partial[:])
+	require.NoError(t, err)
+	assert.Exactly(t, n, len(partial))
+	assert.Exactly(t, expected[:n], string(partial[:]))
+
+	// Empty string
+	r = bytes.NewReader([]byte{})
+	tr = transform.NewReader(r, &expandTransformer{expand: expand_func})
+	actual, err = ioutil.ReadAll(tr)
+	require.NoError(t, err)
+	assert.Exactly(t, "", string(actual))
+}
+
+func TestExpanderOneByteAtATime(t *testing.T) {
+	t.Parallel()
+
+	r := bytes.NewReader([]byte(orig))
+	rr := &oneByteReader{r: r}
+
+	expand_func := func(s string) (string, error) {
+		switch s {
+		case "t3sT":
+			return "test", nil
+		case "i5_":
+			return "is ", nil
+		}
+
+		return "NOMATCH", errors.New("No Match")
+	}
+
+	tr := transform.NewReader(rr, &expandTransformer{expand: expand_func})
+	actual, err := ioutil.ReadAll(tr)
+	require.NoError(t, err)
+	assert.Exactly(t, expected, string(actual))
+}
+
+func TestExpanderFailingTransform(t *testing.T) {
+	t.Parallel()
+
+	r := bytes.NewReader([]byte(orig))
+
+	expand_func := func(s string) (string, error) {
+		switch s {
+		case "t3sT":
+			return "test", nil
+		// missing "i5_" case
+		}
+
+		return "NOMATCH", errors.New("No Match")
+	}
+
+	tr := transform.NewReader(r, &expandTransformer{expand: expand_func})
+	_, err := ioutil.ReadAll(tr)
+	require.Error(t, err)
+}
+
+func TestExpanderMisc(t *testing.T) {
+	t.Parallel()
+
+	tests := [...]struct {
+		orig   string
+		expect string
+	}{
+		{ends_in_dollar, ends_in_dollar},
+		{ends_in_ddollar, ends_in_dollar},
+		{ends_in_var, ends_in_var_expect},
+		{many_dollars_orig, many_dollars_expect},
+	}
+
+	expand_func := func(s string) (string, error) {
+		switch s {
+		case "t3sT":
+			return "test", nil
+			// missing "i5_" case
+		}
+
+		return "NOMATCH", errors.New("No Match")
+	}
+
+	for i, tst := range tests {
+		tst := tst
+		t.Run(fmt.Sprintf("sub=%d", i),
+			func(t *testing.T) {
+				t.Parallel()
+				tr := transform.NewReader(
+					bytes.NewReader([]byte(tst.orig)),
+					&expandTransformer{expand: expand_func},
+				)
+				actual, err := ioutil.ReadAll(tr)
+				require.NoError(t, err)
+				assert.Exactly(t, tst.expect, string(actual))
+			},
+		)
+	}
+}
+
+func TestExpanderLongSrc(t *testing.T) {
+	t.Parallel()
+
+	a := strings.Repeat("a", transformBufSize-1)
+
+	tests := [...]struct {
+		orig   string
+		expect string
+	}{
+		{"foo${a}" + a, "foo" + a + a},
+		{"${a}foo$a", a + "foo" + a},
+		{"$a${", a + "${"},
+	}
+
+	expand_func := func(s string) (string, error) {
+		switch s {
+		case "a":
+			return a, nil
+		}
+
+		return "NOMATCH", errors.New("No Match")
+	}
+
+	for i, tst := range tests {
+		tst := tst
+		t.Run(fmt.Sprintf("sub=%d", i),
+			func(t *testing.T) {
+				t.Parallel()
+				tr := transform.NewReader(
+					&bufReader{buf: []byte(tst.orig)},
+					&expandTransformer{expand: expand_func},
+				)
+				actual, err := ioutil.ReadAll(tr)
+				require.NoError(t, err)
+				assert.Exactly(t, tst.expect, string(actual))
+			},
+		)
+	}
+}
+
+func TestTransformLimit(t *testing.T) {
+	t.Parallel()
+
+	a := strings.Repeat("a", transformBufSize-1)
+
+	// The transform package uses an internal fixed-size buffer.
+	// These tests are expected to fail with specific errors when
+	// that buffer is exceeded.  If they stop failing, then other
+	// tests (above) have likely stopped working correctly too.
+	tests := [...]struct {
+		orig string
+		err  error
+	}{
+		{"$a", transform.ErrShortDst},
+		{"$" + a, transform.ErrShortSrc},
+	}
+
+	expand_func := func(s string) (string, error) {
+		switch s {
+		case "a":
+			return a + "aa", nil
+		case a:
+			return "a", nil
+		}
+
+		return "NOMATCH", errors.New("No Match")
+	}
+
+	for i, tst := range tests {
+		tst := tst
+		t.Run(fmt.Sprintf("sub=%d", i),
+			func(t *testing.T) {
+				t.Parallel()
+				tr := transform.NewReader(
+					bytes.NewReader([]byte(tst.orig)),
+					&expandTransformer{expand: expand_func},
+				)
+				_, err := ioutil.ReadAll(tr)
+				require.EqualError(t, err, tst.err.Error())
+			},
+		)
+	}
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,21 +1,25 @@
-hash: bc86f2e1ca95a651be64c94f23db29be3b606272d03bc66bb8c8efca2b0a3545
-updated: 2017-07-31T12:01:52.034767994-07:00
+hash: fdcf479340c55a75cf42a047276f952cd2847537e12028db6c017479e45ea626
+updated: 2017-08-09T17:47:23.192205998-07:00
 imports:
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
+- name: golang.org/x/text
+  version: 836efe42bb4aa16aaa17b9c155d8813d336ed720
+  subpackages:
+  - transform
 - name: gopkg.in/validator.v2
   version: 07ffaad256c8e957050ad83d6472eb97d785013d
 - name: gopkg.in/yaml.v2
   version: 25c4ec802a7d637f88d584ab26798e94ad14c13b
 testImports:
 - name: github.com/davecgh/go-spew
-  version: adab96458c51a58dc1783b3335dcce5461522e75
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/google/gofuzz
   version: 24818f796faf91cd76ec7bddd72458fbced7a6c1
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/spf13/cast

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,6 +4,9 @@ import:
 - package: gopkg.in/yaml.v2
 - package: github.com/pkg/errors
   version: ~0.8.0
+- package: golang.org/x/text
+  subpackages:
+  - transform
 testImport:
 - package: github.com/google/gofuzz
 - package: github.com/stretchr/testify

--- a/static_provider.go
+++ b/static_provider.go
@@ -23,7 +23,6 @@ package config
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"gopkg.in/yaml.v2"
 )
@@ -36,7 +35,7 @@ type staticProvider struct {
 // accessed via Get method. It is using the yaml marshaler to encode data first,
 // and is subject to panic if data contains a fixed sized array.
 func NewStaticProvider(data interface{}) (Provider, error) {
-	c, err := toReadCloser(data)
+	c, err := toReader(data)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +53,7 @@ func NewStaticProvider(data interface{}) (Provider, error) {
 func NewStaticProviderWithExpand(
 	data interface{},
 	mapping func(string) (string, bool)) (Provider, error) {
-	reader, err := toReadCloser(data)
+	reader, err := toReader(data)
 	if err != nil {
 		return nil, err
 	}
@@ -72,11 +71,11 @@ func (staticProvider) Name() string {
 	return "static"
 }
 
-func toReadCloser(data interface{}) (io.ReadCloser, error) {
+func toReader(data interface{}) (io.Reader, error) {
 	b, err := yaml.Marshal(data)
 	if err != nil {
 		return nil, err
 	}
 
-	return ioutil.NopCloser(bytes.NewBuffer(b)), nil
+	return bytes.NewBuffer(b), nil
 }

--- a/testdata/base.yaml
+++ b/testdata/base.yaml
@@ -1,2 +1,9 @@
 value: base_only
 value_override: base_setting
+a-bool: true
+a-empty: ""
+a-float: 3.14
+a-int: 3
+a-nil:
+a-null: null
+a-string: "3.14"


### PR DESCRIPTION
Currently NewYAMLProviderFromFiles() and NewYAMLProviderWithExpand() do not produce the same result when given the same input, even when the input contains only simple values with no expansion variables.  The expansion feature has a side-effect which converts all fields into strings.

This can be demonstrated with:


    package main

    import "fmt"
    import "os"

    import "go.uber.org/config"

    func main() {
        if len(os.Args) != 3 {
            fmt.Fprintf(os.Stderr, "Usage: %s config.yaml field\n",
                os.Args[0])
            os.Exit(1)
        }

        filename := os.Args[1]
        field := os.Args[2]

        cfg, _ := config.NewYAMLProviderFromFiles(filename)
        val := cfg.Get(field)
        fmt.Printf("%s: %v (%T)\n", field, val.Value(), val.Value())

        cfg, _ = config.NewYAMLProviderWithExpand(os.LookupEnv, filename)
        val = cfg.Get(field)
        fmt.Printf("%s: %v (%T)\n", field, val.Value(), val.Value())
    }

    $ cat test.yaml
    foo:
        bar:
            baz: 13`

    $ ./get-config test.yaml foo.bar.baz
    foo.bar.baz: 13 (int)
    foo.bar.baz: 13 (string)

This series introduces a text.Transformer to perform the variable expansion via an io.ReadCloser so it can be transparently used by newYAMLProviderCore().  It also introduces the escape sequence '$$' which will be replaced by a literal '$'.

fyi @akshayjshah @breerly 

-Brandon