### PR TITLE
Fixed populate panic for a nil pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## v1.1.0 (not released yet)
+## v1.0.2 (2017-08-14)
 
-- No changes yet.
+- Fixed populate panic for a nil pointer.
 
 ## v1.0.1 (2017-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.0.2 (2017-08-14)
+## v1.0.2 (2017-08-17)
 
 - Fixed populate panic for a nil pointer.
 

--- a/static_provider_test.go
+++ b/static_provider_test.go
@@ -413,3 +413,15 @@ func TestTextUnmarshalerOnMissingValue(t *testing.T) {
 	ds := duckTales{}
 	require.NoError(t, p.Get(Root).Populate(&ds))
 }
+
+func TestPopulateNilPointer(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewStaticProvider(13)
+	require.NoError(t, err)
+
+	var i *int
+	err = p.Get(Root).Populate(i)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `can't populate nil *int`)
+}

--- a/value.go
+++ b/value.go
@@ -128,7 +128,12 @@ func (cv Value) Populate(target interface{}) error {
 		return fmt.Errorf("can't populate non pointer type %T", target)
 	}
 
+	ptr := reflect.Indirect(reflect.ValueOf(target))
+	if !ptr.IsValid() {
+		return fmt.Errorf("can't populate nil %T", target)
+	}
+
 	d := decoder{Value: &cv, m: make(map[interface{}]struct{})}
 
-	return d.unmarshal(cv.key, reflect.Indirect(reflect.ValueOf(target)), "")
+	return d.unmarshal(cv.key, ptr, "")
 }

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package config // import "go.uber.org/config"
 
 // Version is the current version of config.
-const Version = "1.1.0"
+const Version = "1.0.2"


### PR DESCRIPTION
We can't populate a value if there no value.
`reflect.Indirect` of a nil pointer returns an invalid `reflect.Value` and panics in the decoder.