### PR TITLE
Convert uintptr to int64/uint64 to compare to max constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## v1.1.0 (not released yet)
+## v1.0.3 (2017-08-25)
 
-- No changes yet.
+- Fixed compilation errors for `GOARCH=arm/x86`.
 
 ## v1.0.2 (2017-08-17)
 

--- a/decoder.go
+++ b/decoder.go
@@ -73,7 +73,7 @@ func convertSignedInts(src interface{}, dst *reflect.Value) error {
 			return nil
 		}
 	case uintptr:
-		if t <= math.MaxInt64 && !dst.OverflowInt(int64(t)) {
+		if int64(t) <= math.MaxInt64 && !dst.OverflowInt(int64(t)) {
 			dst.SetInt(int64(t))
 			return nil
 		}
@@ -119,7 +119,7 @@ func convertUnsignedInts(src interface{}, dst *reflect.Value) error {
 			return nil
 		}
 	case uintptr:
-		if t <= math.MaxUint64 && !dst.OverflowUint(uint64(t)) {
+		if uint64(t) <= math.MaxUint64 && !dst.OverflowUint(uint64(t)) {
 			dst.SetUint(uint64(t))
 			return nil
 		}

--- a/decoder.go
+++ b/decoder.go
@@ -57,7 +57,7 @@ func derefType(t reflect.Type) reflect.Type {
 
 func convertSignedInts(src interface{}, dst *reflect.Value) error {
 	switch t := src.(type) {
-	case int, uint, int8, uint8, int16, uint16, int32, uint32, int64:
+	case int, uint, int8, uint8, int16, uint16, int32, uint32, int64, uint64, uintptr:
 		i, err := strconv.ParseInt(fmt.Sprint(t), 10, 64)
 		if err != nil {
 			return err
@@ -65,16 +65,6 @@ func convertSignedInts(src interface{}, dst *reflect.Value) error {
 
 		if !dst.OverflowInt(i) {
 			dst.SetInt(i)
-			return nil
-		}
-	case uint64:
-		if t <= math.MaxInt64 {
-			dst.SetInt(int64(t))
-			return nil
-		}
-	case uintptr:
-		if int64(t) <= math.MaxInt64 && !dst.OverflowInt(int64(t)) {
-			dst.SetInt(int64(t))
 			return nil
 		}
 	case float32:
@@ -104,23 +94,13 @@ func convertSignedInts(src interface{}, dst *reflect.Value) error {
 
 func convertUnsignedInts(src interface{}, dst *reflect.Value) error {
 	switch t := src.(type) {
-	case int, uint, int8, uint8, int16, uint16, int32, uint32, int64:
+	case int, uint, int8, uint8, int16, uint16, int32, uint32, int64, uint64, uintptr:
 		i, err := strconv.ParseInt(fmt.Sprint(t), 10, 64)
 		if err != nil {
 			return err
 		}
 		if i >= 0 && !dst.OverflowUint(uint64(i)) {
 			dst.SetUint(uint64(i))
-			return nil
-		}
-	case uint64:
-		if !dst.OverflowUint(t) {
-			dst.SetUint(t)
-			return nil
-		}
-	case uintptr:
-		if uint64(t) <= math.MaxUint64 && !dst.OverflowUint(uint64(t)) {
-			dst.SetUint(uint64(t))
 			return nil
 		}
 	case float32:

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -23,6 +23,7 @@ package config
 import (
 	"fmt"
 	"math"
+	"reflect"
 	"testing"
 
 	"github.com/google/gofuzz"
@@ -550,4 +551,16 @@ func TestAddKeyToErrorReturnsNilForNilErrors(t *testing.T) {
 	t.Parallel()
 
 	assert.NoError(t, errorWithKey(nil, "key"))
+}
+
+func TestLargeUintPtr(t *testing.T) {
+	t.Parallel()
+
+	var m uint64 = math.MaxUint32
+	v := reflect.New(reflect.TypeOf(int32(1))).Elem()
+	require.Error(t, convertSignedInts(uintptr(m), &v))
+
+	m = math.MaxInt32
+	require.NoError(t, convertSignedInts(uintptr(m), &v))
+	assert.Equal(t, int32(m), v.Interface())
 }

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package config // import "go.uber.org/config"
 
 // Version is the current version of config.
-const Version = "1.1.0"
+const Version = "1.0.3"


### PR DESCRIPTION
Golang has a different pointer size for arm/x86(4) and x64(8): https://github.com/golang/debug/blob/master/arch/arch.go#L160.
Which leads to a compile error when comparing these types with constant expressions `math.MaxInt64`/ `math.MaxUInt64`.

Fixes https://github.com/uber-go/config/issues/61.