### PR TITLE
Bc/no leak file handles

### DIFF
--- a/static_provider.go
+++ b/static_provider.go
@@ -23,7 +23,6 @@ package config
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"gopkg.in/yaml.v2"
 )
@@ -36,7 +35,7 @@ type staticProvider struct {
 // accessed via Get method. It is using the yaml marshaler to encode data first,
 // and is subject to panic if data contains a fixed sized array.
 func NewStaticProvider(data interface{}) (Provider, error) {
-	c, err := toReadCloser(data)
+	c, err := toReader(data)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +53,7 @@ func NewStaticProvider(data interface{}) (Provider, error) {
 func NewStaticProviderWithExpand(
 	data interface{},
 	mapping func(string) (string, bool)) (Provider, error) {
-	reader, err := toReadCloser(data)
+	reader, err := toReader(data)
 	if err != nil {
 		return nil, err
 	}
@@ -72,11 +71,11 @@ func (staticProvider) Name() string {
 	return "static"
 }
 
-func toReadCloser(data interface{}) (io.ReadCloser, error) {
+func toReader(data interface{}) (io.Reader, error) {
 	b, err := yaml.Marshal(data)
 	if err != nil {
 		return nil, err
 	}
 
-	return ioutil.NopCloser(bytes.NewBuffer(b)), nil
+	return bytes.NewBuffer(b), nil
 }

--- a/yaml.go
+++ b/yaml.go
@@ -139,12 +139,7 @@ func NewYAMLProviderFromFiles(files ...string) (Provider, error) {
 		return nil, err
 	}
 
-	p, err := newYAMLProviderCore(readers...)
-	if err != nil {
-		return nil, err
-	}
-
-	return newCachedProvider(p)
+	return newYAMLProviderFromReader(readers...)
 }
 
 // NewYAMLProviderWithExpand creates a configuration provider from a set of YAML
@@ -196,12 +191,7 @@ func NewYAMLProviderFromBytes(yamls ...[]byte) (Provider, error) {
 		closers[i] = ioutil.NopCloser(bytes.NewReader(yml))
 	}
 
-	p, err := newYAMLProviderCore(closers...)
-	if err != nil {
-		return nil, err
-	}
-
-	return newCachedProvider(p)
+	return newYAMLProviderFromReader(closers...)
 }
 
 func filesToReaders(files ...string) ([]io.ReadCloser, error) {

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -76,7 +76,7 @@ module:
   fake:
     number: ${FAKE_NUMBER:321}`)
 
-	p, err := newYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
+	p, err := newYAMLProviderFromReaderWithExpand(f, cfg)
 	require.NoError(t, err, "Can't create a YAML provider")
 	require.Equal(t, "321", p.Get("module.fake.number").String())
 
@@ -92,7 +92,7 @@ name: some name here
 email: ${EMAIL_ADDRESS}`)
 
 	f := func(string) (string, bool) { return "", false }
-	_, err := newYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
+	_, err := newYAMLProviderFromReaderWithExpand(f, cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `default is empty for "EMAIL_ADDRESS"`)
 }
@@ -105,7 +105,7 @@ name: some name here
 telephone: ${SUPPORT_TEL:}`)
 
 	f := func(string) (string, bool) { return "", false }
-	_, err := newYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
+	_, err := newYAMLProviderFromReaderWithExpand(f, cfg)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `default is empty for "SUPPORT_TEL" (use "" for empty string)`)
@@ -119,7 +119,7 @@ func TestYAMLEnvInterpolationWithColon(t *testing.T) {
 		return "", false
 	}
 
-	p, err := newYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
+	p, err := newYAMLProviderFromReaderWithExpand(f, cfg)
 	require.NoError(t, err, "Can't create a YAML provider")
 
 	require.Equal(t, "this:is:my:value", p.Get("fullValue").String())
@@ -133,7 +133,7 @@ name: ${APP_NAME:my shiny app}
 fullTel: 1-800-LOLZ${TELEPHONE_EXTENSION:""}`)
 
 	f := func(string) (string, bool) { return "", false }
-	p, err := newYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
+	p, err := newYAMLProviderFromReaderWithExpand(f, cfg)
 	require.NoError(t, err, "Can't create a YAML provider")
 
 	require.Equal(t, "my shiny app", p.Get("name").String())
@@ -218,7 +218,7 @@ func TestNewYAMLProviderFromReader(t *testing.T) {
 	t.Parallel()
 
 	buff := bytes.NewBuffer([]byte(_yamlConfig1))
-	provider, err := newYAMLProviderFromReader(ioutil.NopCloser(buff))
+	provider, err := newYAMLProviderFromReader(buff)
 	require.NoError(t, err, "Can't create a YAML provider")
 
 	cs := &configStruct{}
@@ -232,7 +232,7 @@ func TestYAMLNode(t *testing.T) {
 
 	buff := bytes.NewBuffer([]byte("a: b"))
 	node := &yamlNode{value: make(map[interface{}]interface{})}
-	require.NoError(t, unmarshalYAMLValue(ioutil.NopCloser(buff), &node.value))
+	require.NoError(t, unmarshalYAMLValue(buff, &node.value))
 
 	assert.Equal(t, "map[a:b]", node.String())
 	assert.Equal(t, "map[interface {}]interface {}", node.Type().String())
@@ -1196,7 +1196,7 @@ func TestYAMLEnvInterpolationValueMissing(t *testing.T) {
 	cfg := strings.NewReader(`name:`)
 
 	f := func(string) (string, bool) { return "", false }
-	p, err := newYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
+	p, err := newYAMLProviderFromReaderWithExpand(f, cfg)
 	require.NoError(t, err, "Can't create a YAML provider")
 	assert.Equal(t, nil, p.Get("name").Value())
 }
@@ -1211,7 +1211,7 @@ func TestYAMLEnvInterpolationValueConversion(t *testing.T) {
 		return "3", true
 	}
 
-	p, err := newYAMLProviderFromReaderWithExpand(f, ioutil.NopCloser(cfg))
+	p, err := newYAMLProviderFromReaderWithExpand(f, cfg)
 	require.NoError(t, err, "Can't create a YAML provider")
 
 	assert.Equal(t, "3", p.Get("number").String())
@@ -1749,10 +1749,10 @@ func TestMergeErrorsFromReaders(t *testing.T) {
 	t.Parallel()
 
 	t.Run("regular", func(t *testing.T) {
-		base := ioutil.NopCloser(strings.NewReader(`a:
-  - b`))
-		dev := ioutil.NopCloser(strings.NewReader(`a:
-  b: c`))
+		base := strings.NewReader(`a:
+  - b`)
+		dev := strings.NewReader(`a:
+  b: c`)
 
 		_, err := newYAMLProviderFromReader(base, dev)
 		require.Error(t, err)
@@ -1762,10 +1762,10 @@ func TestMergeErrorsFromReaders(t *testing.T) {
 	t.Run("expand", func(t *testing.T) {
 		expand := func(string) (string, bool) { return "", false }
 
-		base := ioutil.NopCloser(strings.NewReader(`a:
-  - b`))
-		dev := ioutil.NopCloser(strings.NewReader(`a:
-  b: c`))
+		base := strings.NewReader(`a:
+  - b`)
+		dev := strings.NewReader(`a:
+  b: c`)
 
 		_, err := newYAMLProviderFromReaderWithExpand(expand, base, dev)
 		require.Error(t, err)
@@ -1805,8 +1805,8 @@ func TestMergeErrorsFromFiles(t *testing.T) {
 		require.NoError(t, err, "Can't read dev file")
 
 		_, err = newYAMLProviderFromReader(
-			ioutil.NopCloser(bytes.NewBuffer(b)),
-			ioutil.NopCloser(bytes.NewBuffer(d)))
+			bytes.NewBuffer(b),
+			bytes.NewBuffer(d))
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "can't merge map")
@@ -1831,8 +1831,8 @@ func TestMergeErrorsFromFiles(t *testing.T) {
 
 		_, err = newYAMLProviderFromReaderWithExpand(
 			expand,
-			ioutil.NopCloser(bytes.NewBuffer(b)),
-			ioutil.NopCloser(bytes.NewBuffer(d)))
+			bytes.NewBuffer(b),
+			bytes.NewBuffer(d))
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "can't merge map")
@@ -1843,13 +1843,15 @@ func TestYAMLProviderWithGarbledPath(t *testing.T) {
 	t.Parallel()
 
 	t.Run("regular", func(t *testing.T) {
-		_, err := NewYAMLProviderFromFiles("/some/nonexisting/config")
+		_, err := NewYAMLProviderFromFiles("./testdata/base.yaml",
+			"/some/nonexisting/config")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no such file or directory")
 	})
 
 	t.Run("expand", func(t *testing.T) {
-		_, err := NewYAMLProviderWithExpand(nil, "/some/nonexisting/config")
+		_, err := NewYAMLProviderWithExpand(nil, "./testdata/base.yaml",
+			"/some/nonexisting/config")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no such file or directory")
 	})


### PR DESCRIPTION
I noticed the other day that file handles are not closed on error, and so file descriptors may be leaked.

May want to slip this patch into the "Perform variable expansion" series (#58) in between commit 78fd180 "yaml.go use newYAMLProviderFromReader() in a couple more places" and commit 0e221a0 "Demonstrate that YAML providers produce different data types", regardless of what is decided about the last commit in that series.

-Brandon