### PR TITLE
Export Provider constructors taking io.Reader

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -374,3 +374,58 @@ rpc:
 	require.NoError(t, v.Populate(cfg))
 	require.Equal(t, 4324, int(*cfg.Outbounds[0].TChannel.Port))
 }
+
+func TestNewYAMLProviderFromBytesWithExpand(t *testing.T) {
+	t.Parallel()
+	txt := []byte(`
+ one:
+   two: hello
+   owner: ${OWNER_EMAIL}
+ `)
+
+	f := func(key string) (string, bool) {
+		if key == "OWNER_EMAIL" {
+			return "hello@there.yasss", true
+		}
+
+		return "", false
+	}
+
+	cfg, err := NewYAMLProviderFromBytesWithExpand(f, txt)
+	require.NoError(t, err, "Can't create a YAML provider")
+
+	assert.Equal(t, "map[one:map[two:hello owner:hello@there.yasss]]", cfg.Get(Root).String())
+}
+
+func TestNewYAMLProviderFromBytesWithExpandInterpolationError(t *testing.T) {
+	t.Parallel()
+	txt := []byte(`
+one:
+  two: hello
+  owner: ${OWNER_EMAIL}
+`)
+
+	f := func(key string) (string, bool) {return "", false}
+	_, err := NewYAMLProviderFromBytesWithExpand(f, txt)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `default is empty for "OWNER_EMAIL"`)
+}
+
+func TestNewYAMLProviderFromBytesWithExpandMergeError(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+map:
+  key: value
+`)
+	dst := []byte(`
+map:
+  - array
+`)
+
+	f := func(key string) (string, bool) {return "", false}
+
+	_, err := NewYAMLProviderFromBytesWithExpand(f, dst, src)
+	require.Error(t, err, "Merge should return an error")
+	assert.Contains(t, err.Error(), `can't merge map[interface{}]interface{} and []interface {}. Source: map["key":"value"]. Destination: ["array"]`)
+}

--- a/expand_test.go
+++ b/expand_test.go
@@ -159,7 +159,7 @@ func TestExpanderFailingTransform(t *testing.T) {
 		switch s {
 		case "t3sT":
 			return "test", nil
-		// missing "i5_" case
+			// missing "i5_" case
 		}
 
 		return "NOMATCH", errors.New("No Match")

--- a/static_provider.go
+++ b/static_provider.go
@@ -40,7 +40,7 @@ func NewStaticProvider(data interface{}) (Provider, error) {
 		return nil, err
 	}
 
-	p, err := newYAMLProviderFromReader(c)
+	p, err := NewYAMLProviderFromReader(c)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func NewStaticProviderWithExpand(
 		return nil, err
 	}
 
-	p, err := newYAMLProviderFromReaderWithExpand(mapping, reader)
+	p, err := NewYAMLProviderFromReaderWithExpand(mapping, reader)
 	if err != nil {
 		return nil, err
 	}

--- a/static_provider_test.go
+++ b/static_provider_test.go
@@ -350,7 +350,7 @@ func TestInterpolatedBool(t *testing.T) {
 		return "", false
 	}
 
-	p, err := newYAMLProviderFromReaderWithExpand(
+	p, err := NewYAMLProviderFromReaderWithExpand(
 		f,
 		ioutil.NopCloser(strings.NewReader("val: ${interpolate:false}")))
 

--- a/yaml.go
+++ b/yaml.go
@@ -236,6 +236,20 @@ func NewYAMLProviderFromBytes(yamls ...[]byte) (Provider, error) {
 	return newYAMLProviderFromReader(readers...)
 }
 
+// NewYAMLProviderFromBytesWithExpand creates a config provider from a byte-backed
+// YAML blobs with ${var} or $var values replaced based on the mapping function.
+func NewYAMLProviderFromBytesWithExpand(
+	mapping func(string) (string, bool),
+	yamls ...[]byte,
+) (Provider, error) {
+	readers := make([]io.Reader, len(yamls))
+	for i, yml := range yamls {
+		readers[i] = bytes.NewReader(yml)
+	}
+
+	return newYAMLProviderFromReaderWithExpand(mapping, readers...)
+}
+
 func filesToReaders(files ...string) ([]io.ReadCloser, error) {
 	// load the files, read their bytes
 	readers := []io.ReadCloser{}

--- a/yaml.go
+++ b/yaml.go
@@ -144,7 +144,7 @@ func NewYAMLProviderFromFiles(files ...string) (Provider, error) {
 		readers[i] = r
 	}
 
-	provider, err := newYAMLProviderFromReader(readers...)
+	provider, err := NewYAMLProviderFromReader(readers...)
 
 	for _, r := range readClosers {
 		nerr := r.Close()
@@ -181,7 +181,7 @@ func NewYAMLProviderWithExpand(mapping func(string) (string, bool), files ...str
 		readers[i] = r
 	}
 
-	provider, err := newYAMLProviderFromReaderWithExpand(mapping,
+	provider, err := NewYAMLProviderFromReaderWithExpand(mapping,
 		readers...)
 
 	for _, r := range readClosers {
@@ -196,7 +196,7 @@ func NewYAMLProviderWithExpand(mapping func(string) (string, bool), files ...str
 
 // NewYAMLProviderFromReader creates a configuration provider from a list of io.Readers.
 // As above, all the objects are going to be merged and arrays/values overridden in the order of the files.
-func newYAMLProviderFromReader(readers ...io.Reader) (Provider, error) {
+func NewYAMLProviderFromReader(readers ...io.Reader) (Provider, error) {
 	p, err := newYAMLProviderCore(readers...)
 	if err != nil {
 		return nil, err
@@ -208,7 +208,7 @@ func newYAMLProviderFromReader(readers ...io.Reader) (Provider, error) {
 // NewYAMLProviderFromReaderWithExpand creates a configuration provider from
 // a list of `io.Readers and uses the mapping function to expand values
 // in the underlying provider.
-func newYAMLProviderFromReaderWithExpand(
+func NewYAMLProviderFromReaderWithExpand(
 	mapping func(string) (string, bool),
 	readers ...io.Reader) (Provider, error) {
 
@@ -221,7 +221,7 @@ func newYAMLProviderFromReaderWithExpand(
 			&expandTransformer{expand: expandFunc})
 	}
 
-	return newYAMLProviderFromReader(ereaders...)
+	return NewYAMLProviderFromReader(ereaders...)
 }
 
 // NewYAMLProviderFromBytes creates a config provider from a byte-backed YAML
@@ -233,21 +233,7 @@ func NewYAMLProviderFromBytes(yamls ...[]byte) (Provider, error) {
 		readers[i] = bytes.NewReader(yml)
 	}
 
-	return newYAMLProviderFromReader(readers...)
-}
-
-// NewYAMLProviderFromBytesWithExpand creates a config provider from a byte-backed
-// YAML blobs with ${var} or $var values replaced based on the mapping function.
-func NewYAMLProviderFromBytesWithExpand(
-	mapping func(string) (string, bool),
-	yamls ...[]byte,
-) (Provider, error) {
-	readers := make([]io.Reader, len(yamls))
-	for i, yml := range yamls {
-		readers[i] = bytes.NewReader(yml)
-	}
-
-	return newYAMLProviderFromReaderWithExpand(mapping, readers...)
+	return NewYAMLProviderFromReader(readers...)
 }
 
 func filesToReaders(files ...string) ([]io.ReadCloser, error) {

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -76,7 +76,7 @@ module:
   fake:
     number: ${FAKE_NUMBER:321}`)
 
-	p, err := newYAMLProviderFromReaderWithExpand(f, cfg)
+	p, err := NewYAMLProviderFromReaderWithExpand(f, cfg)
 	require.NoError(t, err, "Can't create a YAML provider")
 	require.Equal(t, "321", p.Get("module.fake.number").String())
 
@@ -95,7 +95,7 @@ name: some name here
 email: ${EMAIL_ADDRESS}`)
 
 	f := func(string) (string, bool) { return "", false }
-	_, err := newYAMLProviderFromReaderWithExpand(f, cfg)
+	_, err := NewYAMLProviderFromReaderWithExpand(f, cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `default is empty for "EMAIL_ADDRESS"`)
 }
@@ -108,7 +108,7 @@ name: some name here
 telephone: ${SUPPORT_TEL:}`)
 
 	f := func(string) (string, bool) { return "", false }
-	_, err := newYAMLProviderFromReaderWithExpand(f, cfg)
+	_, err := NewYAMLProviderFromReaderWithExpand(f, cfg)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `default is empty for "SUPPORT_TEL" (use "" for empty string)`)
@@ -122,7 +122,7 @@ func TestYAMLEnvInterpolationWithColon(t *testing.T) {
 		return "", false
 	}
 
-	p, err := newYAMLProviderFromReaderWithExpand(f, cfg)
+	p, err := NewYAMLProviderFromReaderWithExpand(f, cfg)
 	require.NoError(t, err, "Can't create a YAML provider")
 
 	require.Equal(t, "this:is:my:value", p.Get("fullValue").String())
@@ -136,7 +136,7 @@ name: ${APP_NAME:my shiny app}
 fullTel: 1-800-LOLZ${TELEPHONE_EXTENSION:""}`)
 
 	f := func(string) (string, bool) { return "", false }
-	p, err := newYAMLProviderFromReaderWithExpand(f, cfg)
+	p, err := NewYAMLProviderFromReaderWithExpand(f, cfg)
 	require.NoError(t, err, "Can't create a YAML provider")
 
 	require.Equal(t, "my shiny app", p.Get("name").String())
@@ -221,7 +221,7 @@ func TestNewYAMLProviderFromReader(t *testing.T) {
 	t.Parallel()
 
 	buff := bytes.NewBuffer([]byte(_yamlConfig1))
-	provider, err := newYAMLProviderFromReader(buff)
+	provider, err := NewYAMLProviderFromReader(buff)
 	require.NoError(t, err, "Can't create a YAML provider")
 
 	cs := &configStruct{}
@@ -1199,7 +1199,7 @@ func TestYAMLEnvInterpolationValueMissing(t *testing.T) {
 	cfg := strings.NewReader(`name:`)
 
 	f := func(string) (string, bool) { return "", false }
-	p, err := newYAMLProviderFromReaderWithExpand(f, cfg)
+	p, err := NewYAMLProviderFromReaderWithExpand(f, cfg)
 	require.NoError(t, err, "Can't create a YAML provider")
 	assert.Equal(t, nil, p.Get("name").Value())
 }
@@ -1214,7 +1214,7 @@ func TestYAMLEnvInterpolationValueConversion(t *testing.T) {
 		return "3", true
 	}
 
-	p, err := newYAMLProviderFromReaderWithExpand(f, cfg)
+	p, err := NewYAMLProviderFromReaderWithExpand(f, cfg)
 	require.NoError(t, err, "Can't create a YAML provider")
 
 	assert.Equal(t, "3", p.Get("number").String())
@@ -1782,7 +1782,7 @@ func TestMergeErrorsFromReaders(t *testing.T) {
 		dev := strings.NewReader(`a:
   b: c`)
 
-		_, err := newYAMLProviderFromReader(base, dev)
+		_, err := NewYAMLProviderFromReader(base, dev)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "can't merge map")
 	})
@@ -1795,7 +1795,7 @@ func TestMergeErrorsFromReaders(t *testing.T) {
 		dev := strings.NewReader(`a:
   b: c`)
 
-		_, err := newYAMLProviderFromReaderWithExpand(expand, base, dev)
+		_, err := NewYAMLProviderFromReaderWithExpand(expand, base, dev)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "can't merge map")
 	})
@@ -1832,7 +1832,7 @@ func TestMergeErrorsFromFiles(t *testing.T) {
 		d, err := ioutil.ReadFile(dev.Name())
 		require.NoError(t, err, "Can't read dev file")
 
-		_, err = newYAMLProviderFromReader(
+		_, err = NewYAMLProviderFromReader(
 			bytes.NewBuffer(b),
 			bytes.NewBuffer(d))
 
@@ -1857,7 +1857,7 @@ func TestMergeErrorsFromFiles(t *testing.T) {
 
 		expand := func(string) (string, bool) { return "", false }
 
-		_, err = newYAMLProviderFromReaderWithExpand(
+		_, err = NewYAMLProviderFromReaderWithExpand(
 			expand,
 			bytes.NewBuffer(b),
 			bytes.NewBuffer(d))


### PR DESCRIPTION
Export the already-existing constructor functions that take `io.Reader`. This
helps build `Provider`s from sources other than files.