### PR TITLE
Add integration tests for NewValue

### DIFF
--- a/value_ext_test.go
+++ b/value_ext_test.go
@@ -64,7 +64,7 @@ func TestValueIntegration(t *testing.T) {
 			true,    // found
 		)
 		assert.Equal(t, "hello", v.Value(), "expected to use user-supplied value")
-		assert.Equal(t, "foo", v.Get("scalar").Value(), "get exposes data not in top-level value") // WAT?!
+		assert.Equal(t, "foo", v.Get("scalar").Value(), "get exposes data not in top-level value") // WAT
 	})
 
 	t.Run("found overrides provider", func(t *testing.T) {
@@ -74,17 +74,21 @@ func TestValueIntegration(t *testing.T) {
 			"foo",    // value
 			false,    // found, doesn't match provider
 		)
-		assert.False(t, v.HasValue(), "unexpected string representation")
+		assert.False(t, v.HasValue(), "HasValue should be false")
+		assert.Equal(t, "foo", v.Value(), "Value should return something") // WAT
 	})
 
-	t.Run("found overrides provider", func(t *testing.T) {
+	t.Run("default re-exposes provider", func(t *testing.T) {
 		v := NewValue(
 			provider,
 			"scalar", // key
-			"foo",    // value
-			false,    // found, doesn't match provider
+			"hello",  // value, doesn't match provider contents
+			true,     // found
 		)
-		assert.False(t, v.HasValue(), "unexpected string representation")
+		assert.Equal(t, "hello", v.Value(), "expected to use user-supplied value")
+		defaulted, err := v.WithDefault("goodbye")
+		require.NoError(t, err, "couldn't set default")
+		assert.Equal(t, "foo", defaulted.Value(), "expected to re-expose provider") // WAT
 	})
 
 	t.Run("populate", func(t *testing.T) {
@@ -95,7 +99,8 @@ func TestValueIntegration(t *testing.T) {
 			"bar",    // value, doesn't match provider contents
 			true,     // found
 		)
+		assert.Equal(t, "bar", v.Value(), "expected to use user-supplied value")
 		require.NoError(t, v.Populate(&s), "error on first populate")
-		assert.Equal(t, "foo", s, "expected to use provider-contained value")
+		assert.Equal(t, "foo", s, "expected to use provider-contained value") // WAT
 	})
 }

--- a/value_ext_test.go
+++ b/value_ext_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValueIntegration(t *testing.T) {
+	provider, err := NewStaticProvider(map[string]interface{}{
+		"scalar":   "foo",
+		"mapping":  map[string]int{"one": 1, "two": 2},
+		"sequence": []int{1, 2},
+	})
+	require.NoError(t, err, "couldn't create static provider")
+
+	t.Run("source is provider name", func(t *testing.T) {
+		v := NewValue(
+			provider,
+			"scalar", // key
+			"foo",    // value
+			true,     // found
+		)
+		assert.Equal(t, provider.Name(), v.Source(), "value source should be provider name")
+	})
+
+	t.Run("value can override provider", func(t *testing.T) {
+		v := NewValue(
+			provider,
+			"scalar", // key
+			"quux",   // value, doesn't match provider contents
+			true,     // found
+		)
+		assert.Equal(t, "quux", v.String(), "unexpected string representation")
+		assert.Equal(t, "quux", v.Value(), "unexpected value")
+	})
+
+	t.Run("get re-exposes provider", func(t *testing.T) {
+		v := NewValue(
+			provider,
+			Root,    // key
+			"hello", // value, doesn't match provider contents
+			true,    // found
+		)
+		assert.Equal(t, "hello", v.Value(), "expected to use user-supplied value")
+		assert.Equal(t, "foo", v.Get("scalar").Value(), "get exposes data not in top-level value") // WAT?!
+	})
+
+	t.Run("found overrides provider", func(t *testing.T) {
+		v := NewValue(
+			provider,
+			"scalar", // key
+			"foo",    // value
+			false,    // found, doesn't match provider
+		)
+		assert.False(t, v.HasValue(), "unexpected string representation")
+	})
+
+	t.Run("found overrides provider", func(t *testing.T) {
+		v := NewValue(
+			provider,
+			"scalar", // key
+			"foo",    // value
+			false,    // found, doesn't match provider
+		)
+		assert.False(t, v.HasValue(), "unexpected string representation")
+	})
+
+	t.Run("populate", func(t *testing.T) {
+		var s string
+		v := NewValue(
+			provider,
+			"scalar", // key
+			"bar",    // value, doesn't match provider contents
+			true,     // found
+		)
+		require.NoError(t, v.Populate(&s), "error on first populate")
+		assert.Equal(t, "foo", s, "expected to use provider-contained value")
+	})
+}


### PR DESCRIPTION
*WIP, but please take a look and discuss.*

This is...unfortunate. Unless users are very careful, the behavior of
`NewValue` is completely irrational. These tests aren't exhaustive, but
the gist is this:

* `NewValue` takes a provider, a key, a value (as `interface{}`), and a
bool indicating whether the value was found or not. There's currently no
validation checking that `value` and `found` match the contents of the
provider at the specified key.
* `HasValue` returns the user-supplied bool, ignoring the contents of
the provider.
* `String` and `Value` return the user-supplied value, ignoring the
contents of the provider.
* `Populate`, `Get`, and `WithDefault` use the provider, ignoring the
user-supplied value and bool.

This leads to a lot of potentially counter-intuitive behavior. Since the
primary use case for `NewValue` is in tests, this is misleading - the
test may not reflect reality at all.

I'm opening this PR to let everyone ponder a good path forwards. There
are 90ish uses of `NewValue` internally, but very few of them use the
`Value` or `HasValue` APIs. I propose this: in `NewValue`, validate that
`value` reflects the contents of the provider at the specified key. If
it doesn't, panic (I know, I know). Ignore `found` completely. Once
validation is complete, just return `provider.Get(key)`. Before cutting
a new release, deprecate `NewValue` and many of the methods on `Value`,
including `Value()` and `HasValue()`.

This keeps most of the API compatible, makes the behavior sane-ish, and
isn't likely to break anyone's production code. Thoughts?