### PR TITLE
Add a small package to deep-merge YAML

### DIFF
--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package merge
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"go.uber.org/config/internal/unreachable"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+type (
+	// YAML has three fundamental types. When unmarshaled into interface{},
+	// they're represented like this.
+	mapping  = map[interface{}]interface{}
+	sequence = []interface{}
+	scalar   = interface{}
+)
+
+// YAML deep-merges any number of YAML sources, with later sources taking
+// priority over earlier ones.
+//
+// Maps are deep-merged. For example,
+//   {"one": 1, "two": 2} + {"one": 42, "three": 3}
+//   == {"one": 42, "two": 2, "three": 3}
+// Sequences are replaced. For example,
+//   {"foo": [1, 2, 3]} + {"foo": [4, 5, 6]}
+//   == {"foo": [4, 5, 6]}
+//
+// In non-strict mode, duplicate map keys are allowed within a single source,
+// with later values overwriting previous ones. Similarly, attempting to merge
+// mismatched types (e.g., merging a sequence into a map) silently fails. To
+// preserve backward compatibility during type mismatches, new values replace
+// existing values.
+//
+// Enabling strict mode returns errors in both of the above cases.
+func YAML(sources []io.Reader, strict bool) (*bytes.Buffer, error) {
+	var merged interface{}
+	for _, r := range sources {
+		d := yaml.NewDecoder(r)
+		d.SetStrict(strict)
+
+		var contents interface{}
+		if err := d.Decode(&contents); err != nil {
+			return nil, fmt.Errorf("couldn't decode source: %v", err)
+		}
+
+		pair, err := merge(merged, contents, strict)
+		if err != nil {
+			return nil, err // error is already descriptive enough
+		}
+		merged = pair
+	}
+
+	buf := bytes.NewBuffer(nil)
+	enc := yaml.NewEncoder(buf)
+	if err := enc.Encode(merged); err != nil {
+		return nil, unreachable.Wrap(fmt.Errorf("couldn't re-serialize merged YAML: %v", err))
+	}
+	return buf, nil
+}
+
+func merge(left, right interface{}, strict bool) (interface{}, error) {
+	// It's possible to handle this with a mass of reflection, but we only need
+	// to merge whole YAML files. Since we're always unmarshaling into
+	// interface{}, we only need to handle a few types. This ends up being
+	// cleaner if we just handle each case explicitly.
+	if left == nil {
+		return right, nil
+	}
+	if right == nil {
+		// Allow higher-priority YAML to explicitly nil out lower-priority entries.
+		return nil, nil
+	}
+	if isScalar(left) && isScalar(right) {
+		return right, nil
+	}
+	if isSequence(left) && isSequence(right) {
+		return right, nil
+	}
+	if isMapping(left) && isMapping(right) {
+		return mergeMapping(left.(mapping), right.(mapping), strict)
+	}
+	// YAML types don't match, so no merge is possible. For backward
+	// compatibility, ignore mismatches unless we're in strict mode and return
+	// the higher-priority value.
+	if !strict {
+		return right, nil
+	}
+	return nil, fmt.Errorf("can't merge a %s and a %s", describe(left), describe(right))
+}
+
+func mergeMapping(left, right mapping, strict bool) (mapping, error) {
+	merged := make(mapping, len(left))
+	for k, v := range left {
+		merged[k] = v
+	}
+	for k := range right {
+		m, err := merge(merged[k], right[k], strict)
+		if err != nil {
+			return nil, err
+		}
+		merged[k] = m
+	}
+	return merged, nil
+}
+
+func isMapping(i interface{}) bool {
+	_, is := i.(mapping)
+	return is
+}
+
+func isSequence(i interface{}) bool {
+	_, is := i.(sequence)
+	return is
+}
+
+func isScalar(i interface{}) bool {
+	return !isMapping(i) && !isSequence(i)
+}
+
+func describe(i interface{}) string {
+	if isMapping(i) {
+		return "mapping"
+	}
+	if isSequence(i) {
+		return "sequence"
+	}
+	return "scalar"
+}

--- a/internal/merge/merge_test.go
+++ b/internal/merge/merge_test.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package merge
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func mustRead(t testing.TB, fname string) []byte {
+	contents, err := ioutil.ReadFile(fname)
+	require.NoError(t, err, "failed to read file: %s", fname)
+	return contents
+}
+
+func dump(t testing.TB, actual, expected string) {
+	// It's impossible to debug YAML if the actual and expected values are
+	// printed on a single line.
+	t.Logf("Actual:\n\n%s\n\n", actual)
+	t.Logf("Expected:\n\n%s\n\n", expected)
+}
+
+func strip(s string) string {
+	// It's difficult to write string constants that are valid YAML. Normalize
+	// strings for ease of testing.
+	s = strings.TrimSpace(s)
+	s = strings.Replace(s, "\t", "  ", -1)
+	return s
+}
+
+func canonicalize(t testing.TB, s string) string {
+	// round-trip to canonicalize formatting
+	var i interface{}
+	require.NoError(t,
+		yaml.Unmarshal([]byte(strip(s)), &i),
+		"canonicalize: couldn't unmarshal YAML",
+	)
+	formatted, err := yaml.Marshal(i)
+	require.NoError(t, err, "canonicalize: couldn't marshal YAML")
+	return string(bytes.TrimSpace(formatted))
+}
+
+func unmarshal(t testing.TB, s string) interface{} {
+	var i interface{}
+	require.NoError(t, yaml.Unmarshal([]byte(strip(s)), &i), "unmarshaling failed")
+	return i
+}
+
+func succeeds(t testing.TB, strict bool, left, right, expect string) {
+	l, r := unmarshal(t, left), unmarshal(t, right)
+	m, err := merge(l, r, strict)
+	require.NoError(t, err, "merge failed")
+
+	actualBytes, err := yaml.Marshal(m)
+	require.NoError(t, err, "couldn't marshal merged structure")
+	actual := canonicalize(t, string(actualBytes))
+	expect = canonicalize(t, expect)
+	if !assert.Equal(t, expect, actual) {
+		dump(t, actual, expect)
+	}
+}
+
+func fails(t testing.TB, strict bool, left, right string) {
+	_, err := merge(unmarshal(t, left), unmarshal(t, right), strict)
+	assert.Error(t, err, "merge succeeded")
+}
+
+func TestIntegration(t *testing.T) {
+	base := mustRead(t, "testdata/base.yaml")
+	prod := mustRead(t, "testdata/production.yaml")
+	expect := mustRead(t, "testdata/expect.yaml")
+
+	merged, err := YAML([]io.Reader{
+		bytes.NewReader(base),
+		bytes.NewReader(prod),
+	}, true /* strict */)
+	require.NoError(t, err, "merge failed")
+
+	if !assert.Equal(t, string(expect), merged.String(), "unexpected contents") {
+		dump(t, merged.String(), string(expect))
+	}
+}
+
+func TestSuccess(t *testing.T) {
+	left := `
+fun: [maserati, porsche]
+practical: {toyota: camry, honda: accord}
+occupants:
+  honda: {driver: jane, backseat: [nate]}
+	`
+	right := `
+fun: [lamborghini, porsche]
+practical: {honda: civic, nissan: altima}
+occupants:
+  honda: {passenger: arthur, backseat: [nora]}
+	`
+	expect := `
+fun: [lamborghini, porsche]
+practical: {toyota: camry, honda: civic, nissan: altima}
+occupants:
+  honda: {passenger: arthur, driver: jane, backseat: [nora]}
+  `
+	succeeds(t, true, left, right, expect)
+	succeeds(t, false, left, right, expect)
+}
+
+func TestErrors(t *testing.T) {
+	check := func(t testing.TB, strict bool, sources ...string) error {
+		readers := make([]io.Reader, len(sources))
+		for i, src := range sources {
+			readers[i] = strings.NewReader(src)
+		}
+		_, err := YAML(readers, strict)
+		return err
+	}
+	t.Run("tabs in source", func(t *testing.T) {
+		src := "foo:\n\tbar:baz"
+		assert.Error(t, check(t, false, src), "expected error in permissive mode")
+		assert.Error(t, check(t, true, src), "expected error in strict mode")
+	})
+
+	t.Run("duplicated keys", func(t *testing.T) {
+		src := `{foo: bar, foo: baz}`
+		assert.NoError(t, check(t, false, src), "expected success in permissive mode")
+		assert.Error(t, check(t, true, src), "expected error in permissive mode")
+	})
+
+	t.Run("merge error", func(t *testing.T) {
+		left := "foo: [1, 2]"
+		right := "foo: {bar: baz}"
+		assert.NoError(t, check(t, false, left, right), "expected success in permissive mode")
+		assert.Error(t, check(t, true, left, right), "expected error in strict mode")
+	})
+}
+
+func TestMismatchedTypes(t *testing.T) {
+	tests := []struct {
+		desc        string
+		left, right string
+	}{
+		{"sequence and mapping", "[one, two]", "{foo: bar}"},
+		{"sequence and scalar", "[one, two]", "foo"},
+		{"mapping and scalar", "{foo: bar}", "foo"},
+		{"nested", "{foo: [one, two]}", "{foo: bar}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc+" strict", func(t *testing.T) {
+			fails(t, true, tt.left, tt.right)
+		})
+		t.Run(tt.desc+" permissive", func(t *testing.T) {
+			// prefer the higher-priority value
+			succeeds(t, false, tt.left, tt.right, tt.right)
+		})
+	}
+}
+
+func TestBooleans(t *testing.T) {
+	// YAML helpfully interprets many strings as Booleans.
+	tests := []struct {
+		in, out string
+	}{
+		{"yes", "true"},
+		{"YES", "true"},
+		{"on", "true"},
+		{"ON", "true"},
+		{"no", "false"},
+		{"NO", "false"},
+		{"off", "false"},
+		{"OFF", "false"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			succeeds(t, true, "", tt.in, tt.out)
+			succeeds(t, false, "", tt.in, tt.out)
+		})
+	}
+}
+
+func TestExplicitNil(t *testing.T) {
+	base := `foo: {one: two}`
+	override := `foo: ~`
+	expect := `foo: ~`
+	succeeds(t, true, base, override, expect)
+	succeeds(t, false, base, override, expect)
+}

--- a/internal/merge/testdata/base.yaml
+++ b/internal/merge/testdata/base.yaml
@@ -1,0 +1,13 @@
+fun:
+  - maserati
+  - porsche
+
+practical:
+  toyota: camry
+  honda: accord
+
+occupants:
+  honda:
+    driver: jane
+    backseat:
+      - nate

--- a/internal/merge/testdata/expect.yaml
+++ b/internal/merge/testdata/expect.yaml
@@ -1,0 +1,13 @@
+fun:
+- lamborghini
+- porsche
+occupants:
+  honda:
+    backseat:
+    - nora
+    driver: jane
+    passenger: arthur
+practical:
+  honda: civic
+  nissan: altima
+  toyota: camry

--- a/internal/merge/testdata/production.yaml
+++ b/internal/merge/testdata/production.yaml
@@ -1,0 +1,13 @@
+fun:
+  - lamborghini
+  - porsche
+
+practical:
+  honda: civic
+  nissan: altima
+
+occupants:
+  honda:
+    passenger: arthur
+    backseat:
+      - nora


### PR DESCRIPTION
Since we're only planning to use this package during process startup,
there's no need to micro-optimize our YAML merging. Given that, we can
implement our deep-merging logic in a small, standalone package that
doesn't require any explicit reflection. That package takes a more naive
approach than our current logic: it unmarshals all YAML sources into
`interface{}`, merges the resulting Go values, and re-serializes the
merged `interface{}` to YAML.