### PR TITLE
Prepare for v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v1.2.0 - 2018-06-28
 ### Added
 - Add `NewYAML`, a new `Provider` constructor that lets callers mix Go values,
   readers, files, and other options.


### PR DESCRIPTION
Update changelog to v1.2.0. The version constant is already at the
correct value.