### PR TITLE
[WIP] Handle empty sources correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2018-07-05
+### Fixed
+- Ignore empty sources rather than returning `io.EOF`.
+
 ## v1.2.0 - 2018-06-28
 ### Added
 - Add `NewYAML`, a new `Provider` constructor that lets callers mix Go values,

--- a/config.go
+++ b/config.go
@@ -95,6 +95,8 @@ func NewYAML(options ...YAMLOption) (y *YAML, retErr error) {
 	dec := yaml.NewDecoder(merged)
 	dec.SetStrict(cfg.strict)
 	if err := dec.Decode(&contents); err != nil {
+		// Decoding can't return EOF, since merging is guaranteed to return a
+		// non-empty reader.
 		return nil, fmt.Errorf("couldn't decode merged YAML: %v", err)
 	}
 
@@ -174,6 +176,8 @@ func (y *YAML) populate(path []string, i interface{}) error {
 	}
 	dec := yaml.NewDecoder(buf)
 	dec.SetStrict(y.strict)
+	// Decoding can't ever return EOF, since encoding any value is guaranteed to
+	// produce non-empty YAML.
 	return dec.Decode(i)
 }
 
@@ -196,6 +200,8 @@ func (y *YAML) withDefault(d interface{}) (*YAML, error) {
 	dec := yaml.NewDecoder(merged)
 	dec.SetStrict(y.strict)
 	if err := dec.Decode(&contents); err != nil {
+		// Decoding can't return EOF, since merging is guaranteed to return a
+		// non-empty reader.
 		return nil, fmt.Errorf("unmarshaling merged YAML failed: %v", err)
 	}
 	return &YAML{


### PR DESCRIPTION
When reading empty files (or using otherwise empty sources), we need to
handle `io.EOF` correctly. Special-case end-of-file where relevant, and
document why we don't need to handle it elsewhere.