### PR TITLE
Handle empty and null sources correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Handle empty sources and top-level nulls correctly.
+
 ## v1.2.0 - 2018-06-28
 ### Added
 - Add `NewYAML`, a new `Provider` constructor that lets callers mix Go values,

--- a/config.go
+++ b/config.go
@@ -30,7 +30,6 @@ import (
 	"go.uber.org/config/internal/merge"
 	"go.uber.org/config/internal/unreachable"
 
-	"go.uber.org/multierr"
 	"golang.org/x/text/transform"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -57,14 +56,11 @@ type YAML struct {
 
 // NewYAML constructs a YAML provider. See the various YAMLOptions for
 // available tweaks to the default behavior.
-func NewYAML(options ...YAMLOption) (y *YAML, retErr error) {
+func NewYAML(options ...YAMLOption) (*YAML, error) {
 	cfg := &config{
 		strict: true,
 		name:   "YAML",
 	}
-	defer func() {
-		retErr = multierr.Append(retErr, cfg.close())
-	}()
 	for _, o := range options {
 		o.apply(cfg)
 	}

--- a/config.go
+++ b/config.go
@@ -50,7 +50,7 @@ const _separator = "."
 // https://godoc.org/gopkg.in/yaml.v2#Marshal for details.
 type YAML struct {
 	name     string
-	raw      []byte
+	raw      [][]byte
 	contents interface{}
 	strict   bool
 }
@@ -90,17 +90,16 @@ func NewYAML(options ...YAMLOption) (y *YAML, retErr error) {
 		merged = bytes.NewBuffer(exp)
 	}
 
-	raw := merged.Bytes() // helpful for WithDefault later on
 	var contents interface{}
 	dec := yaml.NewDecoder(merged)
 	dec.SetStrict(cfg.strict)
-	if err := dec.Decode(&contents); err != nil {
+	if err := dec.Decode(&contents); err != nil && err != io.EOF {
 		return nil, fmt.Errorf("couldn't decode merged YAML: %v", err)
 	}
 
 	return &YAML{
 		name:     cfg.name,
-		raw:      raw,
+		raw:      cfg.sources,
 		contents: contents,
 		strict:   cfg.strict,
 	}, nil
@@ -174,6 +173,8 @@ func (y *YAML) populate(path []string, i interface{}) error {
 	}
 	dec := yaml.NewDecoder(buf)
 	dec.SetStrict(y.strict)
+	// Decoding can't ever return EOF, since encoding any value is guaranteed to
+	// produce non-empty YAML.
 	return dec.Decode(i)
 }
 
@@ -182,7 +183,16 @@ func (y *YAML) withDefault(d interface{}) (*YAML, error) {
 	if err := yaml.NewEncoder(rawDefault).Encode(d); err != nil {
 		return nil, fmt.Errorf("can't marshal default to YAML: %v", err)
 	}
-	sources := []io.Reader{rawDefault, bytes.NewBuffer(y.raw)}
+	// It's possible that one of the sources used when initially configuring the
+	// provider was nothing but a top-level null, but that a higher-priority
+	// source included some additional data. In that case, the result of merging
+	// all the sources is non-null. However, the explicitly-null source should
+	// override all data provided by withDefault. To handle this correctly, we
+	// must use the new defaults as the lowest-priority source and re-merge the
+	// original sources.
+	sources := make([][]byte, 0, len(y.raw)+1)
+	sources = append(sources, rawDefault.Bytes())
+	sources = append(sources, y.raw...)
 	merged, err := merge.YAML(sources, y.strict)
 	if err != nil {
 		// The defaults and the existing config don't agree on the type of a value
@@ -190,17 +200,16 @@ func (y *YAML) withDefault(d interface{}) (*YAML, error) {
 		// sense).
 		return nil, fmt.Errorf("merging default and existing YAML failed: %v", err)
 	}
-	rawMerged := merged.Bytes()
 
 	var contents interface{}
 	dec := yaml.NewDecoder(merged)
 	dec.SetStrict(y.strict)
-	if err := dec.Decode(&contents); err != nil {
+	if err := dec.Decode(&contents); err != nil && err != io.EOF {
 		return nil, fmt.Errorf("unmarshaling merged YAML failed: %v", err)
 	}
 	return &YAML{
 		name:     y.name,
-		raw:      rawMerged,
+		raw:      sources,
 		contents: contents,
 		strict:   y.strict,
 	}, nil
@@ -313,8 +322,9 @@ func (v Value) Value() interface{} {
 }
 
 // WithDefault supplies a default configuration for the value. The default is
-// serialized to YAML, and then the existing configuration is deep-merged into
-// it using the merge logic described in the package-level documentation.
+// serialized to YAML, and then the existing configuration sources are
+// deep-merged into it using the merge logic described in the package-level
+// documentation.
 //
 // Deprecated: the deep-merging behavior of WithDefault is complex, especially
 // when applied multiple times. Instead, create a Go struct, set any defaults

--- a/option.go
+++ b/option.go
@@ -110,11 +110,14 @@ func File(name string) YAMLOption {
 	}
 	all, err := ioutil.ReadAll(f)
 	if err != nil {
+		err = multierr.Append(err, f.Close())
+		return failed(err)
+	}
+	if err := f.Close(); err != nil {
 		return failed(err)
 	}
 	return optionFunc(func(c *config) {
 		c.sources = append(c.sources, all)
-		c.closers = append(c.closers, f)
 	})
 }
 
@@ -141,15 +144,6 @@ type config struct {
 	name    string
 	strict  bool
 	sources [][]byte
-	closers []io.Closer
 	lookup  LookupFunc
 	err     error
-}
-
-func (c *config) close() error {
-	var err error
-	for _, c := range c.closers {
-		err = multierr.Append(err, c.Close())
-	}
-	return err
 }

--- a/option_test.go
+++ b/option_test.go
@@ -22,6 +22,8 @@ package config
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -90,4 +92,22 @@ func TestName(t *testing.T) {
 	require.NoError(t, err, "couldn't construct provider")
 	assert.Equal(t, name, p.Name(), "unexpected provider name")
 	assert.Equal(t, name, p.Get(Root).Source(), "unexpected value source")
+}
+
+func TestSourceErrors(t *testing.T) {
+	f, err := ioutil.TempFile("" /* dir */, "test-source-errors" /* prefix */)
+	require.NoError(t, err, "couldn't create temporary file")
+	// Make reads fail by deleting file.
+	require.NoError(t, f.Close(), "couldn't delete temporary file")
+	require.NoError(t, os.Remove(f.Name()), "couldn't delete temporary file")
+
+	t.Run("source", func(t *testing.T) {
+		_, err = NewYAML(Source(f))
+		require.Error(t, err)
+	})
+
+	t.Run("file", func(t *testing.T) {
+		_, err = NewYAML(File(f.Name()))
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
We're currently handling empty (or comment-only) and null YAML sources
incorrectly. This diff fixes both by simplifying the configuration
provider even further.

These sources are problematic for two reasons. First, we're not
special-casing `io.EOF` errors when we use `yaml.Decoder`. More
insidiously, when we unmarshal sources, we're not distinguishing between
nil values caused by empty (or comment-only) sources and explicit
top-level nulls. The latter is particularly problematic because an
explicit null should be higher-priority than all defaults provided via
`WithDefault`, even if that null is itself overriden by another YAML
source. (For example, if `base.yaml` is just `~` and `production.yaml`
is `foo: bar`, the explicit top-level null in `base.yaml` should trump
any data supplied by `WithDefault`.)

This commit fixes these issues by making three interrelated changes:

1. It changes all YAML options to eagerly consume `io.Reader`s, and
   changes the internal representation of YAML sources to byte slices
   instead of readers. This simplifies later changes, since we'll be
   consuming each source multiple times.
2. It special-cases `io.EOF` errors where appropriate, taking care to
   distinguish empty sources and explicit nulls.
3. It changes `WithDefault`'s internals to match the documentation: the
   implementation literally uses the user-supplied value as the
   lowest-priority search and deep-merges it with all other sources.