### PR TITLE
NewProviderGroup: Handle empty sources correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Undo deprecation of `NewProviderGroup`.
+
 ### Fixed
 - Handle empty sources correctly in `NewProviderGroup`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Handle empty sources correctly in `NewProviderGroup`.
+
 ## 1.2.1 - 2018-07-06
 ### Fixed
 - Handle empty sources and top-level nulls correctly.

--- a/constructors.go
+++ b/constructors.go
@@ -58,7 +58,9 @@ func NewProviderGroup(name string, providers ...Provider) (Provider, error) {
 	opts := make([]YAMLOption, 0, len(providers)+2)
 	opts = append(opts, Name(name), Permissive())
 	for _, p := range providers {
-		opts = append(opts, Static(p.Get(Root).Value()))
+		if v := p.Get(Root); v.HasValue() {
+			opts = append(opts, Static(v.Value()))
+		}
 	}
 	return NewYAML(opts...)
 }

--- a/constructors.go
+++ b/constructors.go
@@ -51,9 +51,9 @@ func NewScopedProvider(prefix string, provider Provider) Provider {
 // documentation. To preserve backward compatibility, the resulting provider
 // disables strict unmarshalling.
 //
-// Deprecated: compose multiple sources of configuration using NewYAML and the
-// Static, File, and/or Source options directly. This enables strict
-// unmarshalling by default and allows use of other options at the same time.
+// Prefer using NewYAML instead of this where possible. NewYAML gives you
+// strict unmarshalling by default and allows use of other options at the same
+// time.
 func NewProviderGroup(name string, providers ...Provider) (Provider, error) {
 	opts := make([]YAMLOption, 0, len(providers)+2)
 	opts = append(opts, Name(name), Permissive())


### PR DESCRIPTION
We were encountering a bug where `NewProviderGroup` was interpreting
empty files correctly despite the previous fix. Specifically, the
following works with `NewYAML`,

    # foo.yaml contains:
    #
    #   foo:
    #     bar: 42

    p := NewYAML(File("foo.yaml"), File("empty.yaml")))
    fmt.Println(p.Get("foo.bar").Value())
    // Output: 42

But the following does not,

    p1 := NewYAML(File("foo.yaml"))
    p2 := NewYAML(File("empty.yaml"))
    p  := NewProviderGroup(p1, p2)
    fmt.Println(p.Get("foo.bar").Value())
    // Output: nil

It doesn't work because `NewProviderGroup` works by calling `Get(Root)`
on the providers and building a new `Provider` with the merged contents.
`p2` doesn't know the difference between empty file and `nil` so it
returns `nil` for its contents, which the merging logic interprets as
unsetting everything at that level.

Unfortunately, switching this call site from `NewProviderGroup` to
`NewYAML` isn't possible because `NewYAML` applies options like
`Permissive` and `Expand` to all files and we don't want to `Expand` on
one of the files.

To fix this, I made two changes:

- YAML providers now have a record of whether they were empty or not.
  When a `Get` is performed on a`YAML` provider, the resulting `Value`
  now accurately knows whether it has a value.
- `NewProviderGroup` includes the contents of a provider only if its
  `Value.HasValue` returns true.

I added failing test cases for this case. I replicated that test for the
null sources case to avoid accidentally breaking it in the future.