### PR TITLE
Lower coverage target to 90%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,7 +7,7 @@ coverage:
     project:                   # measuring the overall project coverage
       default:                 # context, you can create multiple ones with custom titles
         enabled: yes           # must be yes|true to enable this status
-        target: 95             # specify the target coverage for each commit status
+        target: 90             # specify the target coverage for each commit status
                                #   option: "auto" (must increase from parent commit or pull request base)
                                #   option: "X%" a static target percentage to hit
         threshold: null        # allowed to drop X% and still result in a "success" commit status


### PR DESCRIPTION
Our internal OSS process suggests a bar of 90% coverage. We should aim
for more, but let's not block PRs until we drop below that bar.