### PR TITLE
Re-expand env vars in WithDefault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.3.1 - unreleased
+### Fixed
+- Fix environment variable interpolation when `WithDefault` is used.
+
 ## 1.3.0 - 2018-07-30
 ### Added
 - Add a `RawSource` option that selectively disables variable expansion.

--- a/option.go
+++ b/option.go
@@ -156,6 +156,16 @@ func Static(val interface{}) YAMLOption {
 	})
 }
 
+// appendSources appends the given list of YAML sources as-is. Variable
+// expansion will be performed on all passed sources.
+func appendSources(srcs [][]byte) YAMLOption {
+	return optionFunc(func(c *config) {
+		for _, src := range srcs {
+			c.sources = append(c.sources, source{bytes: src})
+		}
+	})
+}
+
 func failed(err error) YAMLOption {
 	return optionFunc(func(c *config) {
 		c.err = multierr.Append(c.err, err)

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package config // import "go.uber.org/config"
 
 // Version is the current semantic version.
-const Version = "1.2.2"
+const Version = "1.3.1"


### PR DESCRIPTION
To make `WithDefault` handle explicit nils correctly, we need to work
directly with the original YAML sources. When re-merging these sources
with the new default source, we neglected to re-expand environment
variables. This effectively made any Values created by `WithDefault`
behave as though environment variable expansion were disabled.

In this commit, we fix this bug by re-expanding env vars in
`WithDefault`. This isn't ideal, since it requires reaching out into the
environment again, but it's very simple. The more-correct alternative
requires parsing all environment variables out of every YAML source and
looking them up during provider construction, then using that lookup
table in subsequent calls to `WithDefault`. Since `WithDefault` is
deprecated and the environment doesn't usually change over the life of
the process, sticking with the simpler implementation seems like a
pragmatic tradeoff.