### PR TITLE
YAML: support non-string scalar keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fix support for non-scalar keys in YAML mappings (eg: "1: car").
+
 ## 1.3.0 - 2018-07-30
 ### Added
 - Add a `RawSource` option that selectively disables variable expansion.

--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -103,13 +103,13 @@ func merge(into, from interface{}, strict bool) (interface{}, error) {
 		// Allow higher-priority YAML to explicitly nil out lower-priority entries.
 		return nil, nil
 	}
-	if isScalar(into) && isScalar(from) {
+	if IsScalar(into) && IsScalar(from) {
 		return from, nil
 	}
-	if isSequence(into) && isSequence(from) {
+	if IsSequence(into) && IsSequence(from) {
 		return from, nil
 	}
-	if isMapping(into) && isMapping(from) {
+	if IsMapping(into) && IsMapping(from) {
 		return mergeMapping(into.(mapping), from.(mapping), strict)
 	}
 	// YAML types don't match, so no merge is possible. For backward
@@ -136,25 +136,25 @@ func mergeMapping(into, from mapping, strict bool) (mapping, error) {
 	return merged, nil
 }
 
-func isMapping(i interface{}) bool {
+func IsMapping(i interface{}) bool {
 	_, is := i.(mapping)
 	return is
 }
 
-func isSequence(i interface{}) bool {
+func IsSequence(i interface{}) bool {
 	_, is := i.(sequence)
 	return is
 }
 
-func isScalar(i interface{}) bool {
-	return !isMapping(i) && !isSequence(i)
+func IsScalar(i interface{}) bool {
+	return !IsMapping(i) && !IsSequence(i)
 }
 
 func describe(i interface{}) string {
-	if isMapping(i) {
+	if IsMapping(i) {
 		return "mapping"
 	}
-	if isSequence(i) {
+	if IsSequence(i) {
 		return "sequence"
 	}
 	return "scalar"


### PR DESCRIPTION
YAML mappings can be keyed by any kind of node so long as it is unique.
That means a mapping key can be an integer, a boolean, or a number of
other types besides a string.

`Get` retrieves a value on a period-separated path and previously
interpreted each segment as a string. This change unmarshals each path
segment to produce comparable map keys, even if it's a bit strange when
"no: car" content produces a value with `provider.Get("false")`.

Resolves #104