### PR TITLE
Minor documentation improvement to Provider

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -29,5 +29,5 @@ const Root = ""
 // of merged YAML, JSON, or TOML files.
 type Provider interface {
 	Name() string         // name of the configuration store
-	Get(key string) Value // retrieves a portion of the configuration
+	Get(key string) Value // retrieves a portion of the configuration, see Value for details
 }


### PR DESCRIPTION
Internally, someone pointed out that the documentation on `Provider.Get`
doesn't point the reader to `Value` or `*YAML`. Since we only document
the path-splitting behavior there, this is a bit misleading.