### PR TITLE
fossa: Run separately, only on push

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -1,0 +1,17 @@
+name: FOSSA Analysis
+on: push
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'uber-go'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: FOSSA analysis
+        uses: fossas/fossa-action@v1
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,11 +27,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
       
-    - name: FOSSA analysis
-      uses: fossas/fossa-action@v1
-      with:
-        api-key: ${{ secrets.FOSSA_API_KEY }}
-
     - name: Load cached dependencies
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
FOSSA analysis currently blocks CI on pull requests because they are
denied access to secrets.

Run FOSSA as a separate job only when we push to a branch of the
project.
