### PR TITLE
CI: Run on Go 1.17/1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.15.x", "1.16.x"]
+        go: ["1.17.x", "1.18.x"]
         include:
-        - go: 1.16.x
+        - go: 1.18.x
           latest: true
 
     steps:
@@ -26,7 +26,7 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v2
-      
+
     - name: Load cached dependencies
       uses: actions/cache@v1
       with:

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,21 @@
 module go.uber.org/config
 
-go 1.13
+go 1.17
 
 require (
 	github.com/stretchr/testify v1.4.0
 	go.uber.org/multierr v1.4.0
 	golang.org/x/lint v0.0.0-20190930215403-16217165b5de
 	golang.org/x/text v0.3.2
-	golang.org/x/tools v0.0.0-20191104232314-dc038396d1f0 // indirect
 	gopkg.in/yaml.v2 v2.2.5
+)
+
+require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.uber.org/atomic v1.5.0 // indirect
+	go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee // indirect
+	golang.org/x/tools v0.0.0-20191104232314-dc038396d1f0 // indirect
+	honnef.co/go/tools v0.0.1-2019.2.3 // indirect
 )

--- a/tools_test.go
+++ b/tools_test.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build tools
 // +build tools
 
 package config


### PR DESCRIPTION
We only support the most recent two Go minor versions.
