### PR TITLE
Use Go 1.19 and run gofmt

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.17.x", "1.18.x"]
+        go: ["1.17.x", "1.18.x", "1.19.x"]
         include:
-        - go: 1.18.x
+        - go: 1.19.x
           latest: true
 
     steps:

--- a/config.go
+++ b/config.go
@@ -124,11 +124,14 @@ func (y *YAML) Name() string {
 // Get retrieves a value from the configuration. The supplied key is treated
 // as a period-separated path, with each path segment used as a map key. For
 // example, if the provider contains the YAML
-//   foo:
-//     bar:
-//       baz: hello
+//
+//	foo:
+//	  bar:
+//	    baz: hello
+//
 // then Get("foo.bar") returns a value holding
-//   baz: hello
+//
+//	baz: hello
 //
 // To get a value holding the entire configuration, use the Root constant as
 // the key.
@@ -293,11 +296,14 @@ func (v Value) Populate(target interface{}) error {
 // values. The supplied path is split on periods, and each segment is treated
 // as a nested map key. For example, if the current value holds the YAML
 // configuration
-//   foo:
-//     bar:
-//       baz: quux
+//
+//	foo:
+//	  bar:
+//	    baz: quux
+//
 // then a call to Get("foo.bar") will hold the YAML mapping
-//   baz: quux
+//
+//	baz: quux
 func (v Value) Get(path string) Value {
 	if path == Root {
 		return v

--- a/doc.go
+++ b/doc.go
@@ -24,7 +24,7 @@
 // YAML, but may be extended in the future to support more restrictive
 // encodings like JSON or TOML.
 //
-// Merging Configuration
+// # Merging Configuration
 //
 // It's often convenient to separate configuration into multiple files; for
 // example, an application may want to first load some universally-applicable
@@ -36,56 +36,60 @@
 // consider a scalar) are merged by replacing lower-priority values with
 // higher-priority overrides. For example, consider this merge of base.yaml
 // and override.yaml:
-//   # base.yaml
-//   some_key: foo
 //
-//   # override.yaml
-//   some_key: bar
+//	# base.yaml
+//	some_key: foo
 //
-//   # merged result
-//   some_key: bar
+//	# override.yaml
+//	some_key: bar
+//
+//	# merged result
+//	some_key: bar
 //
 // Slices, arrays, and anything else YAML would consider a sequence are also
 // replaced. Again merging base.yaml and override.yaml:
-//   # base.yaml
-//   some_key: [foo, bar]
 //
-//   # override.yaml
-//   some_key: [baz, quux]
+//	# base.yaml
+//	some_key: [foo, bar]
 //
-//   # merged output
-//   some_key: [baz, quux]
+//	# override.yaml
+//	some_key: [baz, quux]
+//
+//	# merged output
+//	some_key: [baz, quux]
 //
 // Maps are recursively deep-merged, handling scalars and sequences as
 // described above. Consider a merge between a more complex set of YAML files:
-//   # base.yaml
-//   some_key:
-//     foo: bar
-//     foos: [1, 2]
 //
-//   # override.yaml
-//   some_key:
-//     baz: quux
-//     foos: [3, 4]
+//	  # base.yaml
+//	  some_key:
+//	    foo: bar
+//	    foos: [1, 2]
 //
-//  # merged output
-//	some_key:
-//	  foo: bar      # from base.yaml
-//	  baz: quux     # from override.yaml
-//	  foos: [3, 4]  # from override.yaml
+//	  # override.yaml
+//	  some_key:
+//	    baz: quux
+//	    foos: [3, 4]
+//
+//	 # merged output
+//		some_key:
+//		  foo: bar      # from base.yaml
+//		  baz: quux     # from override.yaml
+//		  foos: [3, 4]  # from override.yaml
 //
 // In all cases, explicit nils (represented in YAML with a tilde) override any
 // pre-existing configuration. For example,
-//   # base.yaml
-//   foo: {bar: baz}
 //
-//   # override.yaml
-//   foo: ~
+//	# base.yaml
+//	foo: {bar: baz}
 //
-//   # merged output
-//   foo: ~
+//	# override.yaml
+//	foo: ~
 //
-// Strict Unmarshalling
+//	# merged output
+//	foo: ~
+//
+// # Strict Unmarshalling
 //
 // By default, the NewYAML constructor enables gopkg.in/yaml.v2's strict
 // unmarshalling mode. This prevents a variety of common programmer errors,
@@ -98,12 +102,13 @@
 // To maintain backward compatibility, all other constructors default to
 // permissive unmarshalling.
 //
-// Quote Strings
+// # Quote Strings
 //
 // YAML allows strings to appear quoted or unquoted, so these two lines are
 // identical:
-//   foo: bar
-//   "foo": "bar"
+//
+//	foo: bar
+//	"foo": "bar"
 //
 // However, the YAML specification special-cases some unquoted strings. Most
 // obviously, true and false are interpreted as Booleans (unless quoted). Less
@@ -114,12 +119,13 @@
 // Correctly deep-merging sources requires this package to unmarshal and then
 // remarshal all YAML, which implicitly converts these special-cased unquoted
 // strings to their canonical representation. For example,
-//   foo: yes  # before merge
-//   foo: true # after merge
+//
+//	foo: yes  # before merge
+//	foo: true # after merge
 //
 // Quoting special-cased strings prevents this surprising behavior.
 //
-// Deprecated APIs
+// # Deprecated APIs
 //
 // Unfortunately, this package was released with a variety of bugs and an
 // overly large API. The internals of the configuration provider have been

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/config
 
-go 1.17
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -37,7 +37,6 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -42,11 +42,14 @@ type (
 // priority over earlier ones.
 //
 // Maps are deep-merged. For example,
-//   {"one": 1, "two": 2} + {"one": 42, "three": 3}
-//   == {"one": 42, "two": 2, "three": 3}
+//
+//	{"one": 1, "two": 2} + {"one": 42, "three": 3}
+//	== {"one": 42, "two": 2, "three": 3}
+//
 // Sequences are replaced. For example,
-//   {"foo": [1, 2, 3]} + {"foo": [4, 5, 6]}
-//   == {"foo": [4, 5, 6]}
+//
+//	{"foo": [1, 2, 3]} + {"foo": [4, 5, 6]}
+//	== {"foo": [4, 5, 6]}
 //
 // In non-strict mode, duplicate map keys are allowed within a single source,
 // with later values overwriting previous ones. Attempting to merge

--- a/option.go
+++ b/option.go
@@ -49,9 +49,11 @@ func (f optionFunc) apply(c *config) { f(c) }
 // Expand allows variable references to take two forms: $VAR or
 // ${VAR:default}. In the first form, variable names MUST adhere to shell
 // naming rules:
-//   ...a word consisting solely of underscores, digits, and alphabetics form
-//   the portable character set. The first character of a name may not be a
-//   digit.
+//
+//	...a word consisting solely of underscores, digits, and alphabetics form
+//	the portable character set. The first character of a name may not be a
+//	digit.
+//
 // In this form, NewYAML returns an error if any referenced variables aren't
 // found.
 //


### PR DESCRIPTION
This makes the CI run on Go 1.19, and fix the formatting issues per the new go doc format in 1.19.